### PR TITLE
fix: plan generation wasn't considering all cases

### DIFF
--- a/backend/app/plan/generation.py
+++ b/backend/app/plan/generation.py
@@ -189,7 +189,7 @@ def _get_credits(courseinfo: CourseInfo, courseid: PseudoCourse) -> int:
 
 def _determine_coreq_components(
     courseinfo: CourseInfo, courses_to_pass: list[PseudoCourse]
-) -> dict[str, list[PseudoCourse]]:
+) -> dict[PseudoCourse, list[PseudoCourse]]:
     """
     Determine which courses have to be taken together because they are
     mutual corequirements.
@@ -201,8 +201,8 @@ def _determine_coreq_components(
         coreqs.append(_get_corequirements(courseinfo, courseid))
 
     # Start off with each course in its own connected component
-    coreq_components: dict[str, list[PseudoCourse]] = {
-        courseid.code: [courseid] for courseid in courses_to_pass
+    coreq_components: dict[PseudoCourse, list[PseudoCourse]] = {
+        courseid: [courseid] for courseid in courses_to_pass
     }
 
     # Determine which pairs of courses are corequirements of each other
@@ -215,11 +215,11 @@ def _determine_coreq_components(
                 # `course1` and `course2` are mutual corequirements, they must be taken
                 # together
                 # Merge the connected components
-                dst = coreq_components[course1.code]
-                src = coreq_components[course2.code]
+                dst = coreq_components[course1]
+                src = coreq_components[course2]
                 dst.extend(src)
                 for c in src:
-                    coreq_components[c.code] = dst
+                    coreq_components[c] = dst
 
     return coreq_components
 
@@ -349,7 +349,7 @@ async def generate_recommended_plan(passed: ValidatablePlan):
         could_use_more_credits = False
         some_requirements_missing = False
         for try_course in courses_to_pass:
-            course_group = coreq_components[try_course.code]
+            course_group = coreq_components[try_course]
 
             status = _try_add_course_group(
                 courseinfo, plan, courses_to_pass, credits, course_group


### PR DESCRIPTION
### ¿Qué se arregla?
- Al generar un plan recomendado ocurría un problema que produce un error en algunos casos. En particular, pasaba que al agrupar correquisitos por atributo `.code` se perdía info cuando había un curso no concreto repetido con distintos creditajes. Por ejemplo, con mi RUT se hechaba debido a que tengo varios OFGs pendientes, donde algunos valen 10 y otros 5 creditos, pero se agrupaban todos por `.code` igual a `!L1`.

### ¿Cómo se soluciona?
- Simplemente modifiqué el diccionario para que use como llave la instancia de pseudo curso en véz de solo el `.code`.

### Posibles mejoras
- Primero probé una solución que me parece mejor, la cuál consistía en usar una tupla (`.code`, `.credits` | `None`) como llave. Esta funcionaba bien, pero siento que desordenaba mucho el código y daba espacio para la creación de una nueva estructura. Al final opté por tomar un camino más simple, ya que la solución actual no debería traer problemas porque el diccionario de correquisitos siempre será muy limitado.