### PR TITLE
fix: patch concrete courses duplication PAN-141

### DIFF
--- a/backend/app/plan/generation.py
+++ b/backend/app/plan/generation.py
@@ -115,7 +115,9 @@ def _compute_courses_to_pass(
 
     consumed: list[set[str]] = [set() for _sem in passed_classes]
     to_pass: list[PseudoCourse] = []
-    # TODO: prioritize by superblocks (e.g. 1.title 2.major 3.minor ...)
+    # TODO: Prioritize by superblocks (e.g. 1.title 2.major 3.minor ...)
+    #       Even further, reuse the main curriculum solver since all curriculum quirks
+    #       should still apply here
     # first, compute all concrete courses
     for required_sem in required_classes:
         for required in required_sem:


### PR DESCRIPTION
### ¿Qué se arregla?
- Al generar un plan recomendado se buscan los cursos que falta aprobar con la función `_compute_courses_to_pass`. Resulta que en esta función aún no implementamos la priorización por grupos (e.g. primero titulo, luego major, luego minor, etc) por lo que en mi caso particular se intenta llenar el bloque de optativo de fundamentos antes que el curso mat discretas. Por esta razón, se asigna mat discretas a dicho grupo y luego se duplica mat discretas para suplir con la falta de este:
<p align="center">
<img src="https://github.com/open-source-uc/planner/assets/27508976/0adcf1d4-8f25-4410-955c-010db6757c98"  width="600">
</p>

### ¿Cómo se soluciona?
- Hice que se priorice el cálculo de todos los cursos concretos antes que cualquier equivalencia. Me parece que esta es una solución parche para el problema global, ya que eventualmente tenemos que priorizar por grupos, pero mientras no sepamos como lo hace Siding por detrás encuentro que este parche avanza en la dirección correcta. Además, me hace sentido ya que no veo razón alguna para que una equivalencia se deba calcular antes que un curso concreto aprobado.

### Futuras mejoras
- Priorizar por grupos como mencioné antes.