### PR TITLE
Remake de filtros de búsqueda

### DIFF
--- a/frontend/src/client/models/CourseOverview.ts
+++ b/frontend/src/client/models/CourseOverview.ts
@@ -6,5 +6,6 @@ export type CourseOverview = {
     code: string;
     name: string;
     credits: number;
+    school: string;
 };
 

--- a/frontend/src/client/services/DefaultService.ts
+++ b/frontend/src/client/services/DefaultService.ts
@@ -112,8 +112,8 @@ export class DefaultService {
 
     /**
      * Search Courses
-     * Fetches a list of courses that match the given name (including code),
-     * credits, and school.
+     * Fetches a list of courses that match the given name (or code),
+     * credits and school.
      * @param name
      * @param credits
      * @param school
@@ -165,19 +165,29 @@ export class DefaultService {
 
     /**
      * Get Equivalence Details
-     * For a list of equivalence codes, fetch a corresponding list of equivalence details.
+     * For a list of equivalence codes, fetch a corresponding list of equivalence details
+     * with the `courses` attribute filtered.
      * @param codes
+     * @param filterName
+     * @param filterCredits
+     * @param filterSchool
      * @returns Equivalence Successful Response
      * @throws ApiError
      */
     public static getEquivalenceDetails(
         codes: Array<string>,
+        filterName?: string,
+        filterCredits?: number,
+        filterSchool?: string,
     ): CancelablePromise<Array<Equivalence>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/equivalences',
             query: {
                 'codes': codes,
+                'filter_name': filterName,
+                'filter_credits': filterCredits,
+                'filter_school': filterSchool,
             },
             errors: {
                 422: `Validation Error`,


### PR DESCRIPTION
## ¿Qué se implementa?
- capacidad de filtro para el endpoint `get_equivalence_details`.
- capa de abstracción para mejorar el filtro de búsqueda y acoplarlo.
- incorporación de atributo `school` a la respuesta de búsqueda a petición de @Diegothx .

### ¿Cómo?
- creando las funciones `_get_course_filter` y `_filter_courses` para mejor las capacidades de búsqueda de los endpoint `search_courses` y `get_equivalence_details`.

## Ejemplo

### Request
"Todos los OFG teológicos de 10 créditos que contienen la palabra cristologia"
`localhost:8000/equivalences?codes=!L1&filter_credits=10&filter_name=cristologia&filter_school=teo`
![image](https://github.com/open-source-uc/planner/assets/27508976/09f78411-2908-489a-b674-4d6a61a8ee6d)
### Respuesta
![image](https://github.com/open-source-uc/planner/assets/27508976/a35075be-078b-48e8-ba80-1e3f264f0b85)
