### PR TITLE
Minimizacion de bandeja de error y arreglo overlay bandeja a lista de curriculumns (PAN-179 PAN-168)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,7 +31,7 @@
   .card {
     background-color: #D8D8D8;
     height: 90px;
-    border-radius: theme('borderRadius.lg');
+    border-radius: theme('borderRadius.md');
     padding: theme('spacing.1');
     box-shadow: theme('boxShadow.lg');
     position: relative;
@@ -41,7 +41,7 @@
     transition: opacity 0.5s ease;
   }
   .darkBlue{
-    background-color: #3D4451;
+    background-color: #00345E; /*#3D4451*/
   }
   .btn{
     @apply font-semibold py-2 px-4 rounded;
@@ -71,24 +71,34 @@
 }
 
 .block-PC{
-  background-color: #93F6E8; /*#FFC840*/
+  /*background-color: #FEC60D;*/
+  background-color: #93F6E8;
 }
 
 .block-FG{
-  background-color: #355484; /*#483D8B*/
+  background-color: #355484;  
+  /*background-color: #00345E;*/ 
   color: white;
 }
 
 .block-M{
-  background-color: #B3A9E4; /*#F74F23*/
+  /*background-color: #F74F23; */
+  /*background-color: #D91E0E;*/
+  /*background-color: #FF4136 ;*/
+  background-color:#B3A9E4;
 }
 
 .block-m{
-  background-color: #13CDB2; /*#32CD33*/
+  /*background-color: #32CD33; */
+  /*background-color: #2ECC40;*/
+  background-color:#13CDB2;
 }
 
 .block-T{
   background-color: #9966CC;
+  /*background-color: #B10DC9;*/
+  /*color: white;*/
+  /*background-color:/*#9966cc;*/
 }
 
 .hover-text {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,7 +22,7 @@
     @apply text-base pl-1 pr-1 text-left;
   }
   .curriculumSelector .selectorElement .curriculumOptions {
-    @apply absolute mt-1 max-h-96 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm;
+    @apply fixed mt-1 max-h-96 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm;
   }
   .curriculumSelector .selectorElement .curriculumOptions .curriculumOption{
     @apply relative cursor-default select-none py-1.5 pl-8 pr-4 ;

--- a/frontend/src/pages/planner/CourseSelectorDialog.tsx
+++ b/frontend/src/pages/planner/CourseSelectorDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, Fragment } from 'react'
+import { useState, useEffect, Fragment, memo } from 'react'
 import { Dialog, Transition, Switch } from '@headlessui/react'
 import { DefaultService, EquivDetails, CourseOverview, CourseDetails, CancelablePromise } from '../../client'
 import { Spinner } from '../../components/Spinner'
@@ -391,4 +391,4 @@ const CourseSelectorDialog = ({ equivalence, open, onClose }: { equivalence?: Eq
   )
 }
 
-export default CourseSelectorDialog
+export default memo(CourseSelectorDialog)

--- a/frontend/src/pages/planner/CourseSelectorDialog.tsx
+++ b/frontend/src/pages/planner/CourseSelectorDialog.tsx
@@ -180,7 +180,7 @@ const CourseSelectorDialog = ({ equivalence, open, onClose }: { equivalence?: Eq
 
   return (
     <Transition.Root show={open} as={Fragment}>
-    <Dialog as="div" className="relative z-10" onClose={() => { setSelectedCourse(undefined); onClose() }}>
+    <Dialog as="div" className="relative z-50" onClose={() => { setSelectedCourse(undefined); onClose() }}>
       <Transition.Child
           as={Fragment}
           enter="ease-out duration-200"

--- a/frontend/src/pages/planner/CurriculumSelector.tsx
+++ b/frontend/src/pages/planner/CurriculumSelector.tsx
@@ -136,7 +136,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
             />
           }
         </li>
-        {planName !== '' && <li className={'inline text-md ml-5 font-semibold'}><div className={'text-sm inline mr-1 font-normal'}>Plan:</div> {planName}</li>}
+        {planName !== '' && <li className={'inline text-md ml-3 font-semibold'}><div className={'text-sm inline mr-1 font-normal'}>Plan:</div> {planName}</li>}
       </ul>
   )
 })

--- a/frontend/src/pages/planner/CurriculumSelector.tsx
+++ b/frontend/src/pages/planner/CurriculumSelector.tsx
@@ -44,7 +44,7 @@ const Selector = memo(function _Selector ({
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >
-        <Listbox.Options className="curriculumOptions" style={{ zIndex: 1 }}>
+        <Listbox.Options className="curriculumOptions overflow-visible z-40">
           {Object.keys(data).map((key) => (
             <Listbox.Option
               className={({ active }) =>

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -5,12 +5,12 @@ import { Spinner } from '../../components/Spinner'
 /**
  * This is what is displayed when there are no errors or warnings.
  */
-const NoMessages = (): JSX.Element => {
+const NoMessages = ({ open }: { open: boolean }): JSX.Element => {
   return (
     <div className="flex p-4 mb-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 " role="alert">
       <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
       <span className="sr-only">Info</span>
-      <div>
+      <div className={`min-w-[14rem] ${open ? '' : 'hidden'} `}>
         <span className='font-medium'>Felicitaciones!</span> No hay errores o advertencias.
       </div>
     </div>
@@ -52,27 +52,27 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
   })
   const messageList: JSX.Element[] = diagnostics.map((diag, index) => Message(diag, index, open || hasError))
   return (
-    <div className="h-[95%] flex relative">
-      <div className={`h-16 absolute ${hasError ? 'translate-x-0' : '-translate-x-4'} z-10 motion-reduce:transition-none transition-all`}>
-        <button className="h-full bg-slate-100 rounded-l-lg border-slate-300 border-t-2 border-b-2 border-l-2 text-slate-500 focus:outline-none" onClick={() => setOpen(prev => !prev)}>
-            <svg className={`w-4 h-4 ${hasError || open ? '' : 'transform rotate-180'}`} viewBox="0 0 24 24" fill="currentColor">
-              <path d="M0 0h24v24H0z" fill="none" />
-              <path d="M8 5v14l11-7z" />
-            </svg>
-          </button>
-        </div>
-      <div className={` border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${!hasError ? 'rounded-tl-none' : ''} ${hasError || open ? 'w-80 min-w-[200px]' : 'w-20'}`}>
-        <div className={`relative mb-2 overflow-y-auto h-full w-full py-4 rounded-lg  bg-slate-100 z-20 px-4 ${!hasError ? 'rounded-tl-none' : ''}`}>
-        <div className='flex mb-4 justify-center'>
-          <svg aria-hidden="true" className="flex-shrink-0 inline w-6 h-7" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path>
-          </svg>
-          {(hasError || open) && <p className="whitespace-nowrap ml-1 text-xl font-semibold text-center h-7 overflow-hidden">Errores y Advertencias </p>}
+    <div className={`h-[95%] flex relative border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${hasError || open ? 'w-80 min-w-[20rem]' : 'w-20'}`}>
+      <div className='relative mb-2 overflow-y-auto h-full w-full py-4 rounded-lg  bg-slate-100 z-20 px-4'>
+        <div className='flex mb-4 mx-3'>
+          <div className='group relative flex'>
+            <span className={`fixed z-10 transition-all motion-reduce:transition-none scale-0 ${hasError ? 'group-hover:scale-100' : ''}`}>
+              <div className="absolute right-2.5 top-1 w-4 h-4 bg-gray-800 rotate-45 rounded" />
+              <span className={'absolute right-4 -top-1 w-48 z-10 rounded bg-gray-800 p-2 text-xs text-white'}>
+                Es necesario resolver todos los errores existentes para minimizar la bandeja de Errores y Advertencias.
+              </span>
+            </span>
+            <button className={`${hasError ? 'cursor-not-allowed stroke-slate-400' : 'stroke-current'}`} disabled={hasError} onClick={() => setOpen(prev => !prev)}>
+              <svg className="w-5 h-5 flex" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M2 12h20M2 6h20M2 18h20"></path>
+              </svg>
+            </button>
+          </div>
+          {(hasError || open) && <p className="whitespace-nowrap ml-2 text-xl font-semibold text-center h-7 overflow-hidden">Errores y Advertencias </p>}
         </div>
         <div className="flex flex-col gap-2">
-          {validating ? <Spinner message='Validando...'/> : <>{messageList.length > 0 ? messageList : <NoMessages/>}</>}
+            {validating ? <Spinner message={`${hasError || open ? 'Validando...' : ''}`}/> : <>{messageList.length > 0 ? messageList : <NoMessages open={hasError || open}/>}</>}
         </div>
-      </div>
       </div>
     </div>
   )

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -7,10 +7,10 @@ import { Spinner } from '../../components/Spinner'
  */
 const NoMessages = ({ open }: { open: boolean }): JSX.Element => {
   return (
-    <div className="flex p-4 mb-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 " role="alert">
-      <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
+    <div className="flex p-3 mb-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 " role="alert">
+      <svg aria-hidden="true" className="flex-shrink-0 inline-flex w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
       <span className="sr-only">Info</span>
-      <div className={`min-w-[14rem] ${open ? '' : 'hidden'} `}>
+      <div className={`min-w-[14rem] ml-2 s${open ? '' : 'hidden'} `}>
         <span className='font-medium'>Felicitaciones!</span> No hay errores o advertencias.
       </div>
     </div>
@@ -24,8 +24,8 @@ const Message = (diag: FlatDiagnostic, key: number, open: boolean): JSX.Element 
   const w = diag.is_warning
 
   return (
-  <div key={key} className={`overflow-hidden flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
-    <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
+  <div key={key} className={`motion-reduce:transition-none transition-all  overflow-hidden flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
+    <svg aria-hidden="true" className="flex-shrink-0 inline-flex w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
     <span className="sr-only">Info</span>
     <div className={`min-w-[14rem] ml-2 ${open ? '' : 'hidden'} `}>
       <span className={'font-semibold '}>{`${w ? 'Advertencia' : 'Error'}: `}</span>
@@ -51,9 +51,9 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
     }
   })
   const messageList: JSX.Element[] = diagnostics.map((diag, index) => Message(diag, index, open || hasError))
+
   return (
-    <div className={`h-[95%] flex relative border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${hasError || open ? 'w-80 min-w-[20rem]' : 'w-[4.5rem]'}`}>
-      <div className='relative mb-2 overflow-y-auto h-full w-full py-4 rounded-lg  bg-slate-100 z-20 px-3'>
+      <div className={`h-[95%] z-20 flex flex-col relative border-slate-300 border-2 rounded-lg bg-slate-100 shadow-lg mb-2 overflow-y-auto overflow-x-hidden  py-4 px-3  motion-reduce:transition-none transition-all ${hasError || open ? 'w-80 min-w-[20rem]' : 'min-w-[4.5rem]'}`}>
         <div className='flex mb-4 mx-3'>
           <div className='group relative flex'>
             <span className={`fixed z-10 transition-all motion-reduce:transition-none scale-0 ${hasError ? 'group-hover:scale-100' : ''}`}>
@@ -63,18 +63,17 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
               </span>
             </span>
             <button className={`${hasError ? 'cursor-not-allowed stroke-slate-400' : 'stroke-current'}`} disabled={hasError} onClick={() => setOpen(prev => !prev)}>
-              <svg className="w-5 h-5 flex" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg className="w-5 h-5 flex " xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M2 12h20M2 6h20M2 18h20"></path>
               </svg>
             </button>
           </div>
           {(hasError || open) && <p className="whitespace-nowrap ml-2 text-xl font-semibold text-center h-7 overflow-hidden">Errores y Advertencias </p>}
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 w-fit">
             {validating ? <Spinner message={`${hasError || open ? 'Validando...' : ''}`}/> : <>{messageList.length > 0 ? messageList : <NoMessages open={hasError || open}/>}</>}
         </div>
       </div>
-    </div>
   )
 }
 

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { FlatDiagnostic } from '../../client'
 import { Spinner } from '../../components/Spinner'
 
@@ -5,33 +6,40 @@ import { Spinner } from '../../components/Spinner'
  * This is what is displayed when there are no errors or warnings.
  */
 const NoMessages = (): JSX.Element => {
-  return (<div className="flex p-4 mb-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 " role="alert">
-  <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
-  <span className="sr-only">Info</span>
-  <div>
-    <span className='font-medium'>Felicitaciones!</span> No hay errores o advertencias.
-  </div>
-</div>)
+  return (
+    <div className="flex p-4 mb-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 " role="alert">
+      <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
+      <span className="sr-only">Info</span>
+      <div>
+        <span className='font-medium'>Felicitaciones!</span> No hay errores o advertencias.
+      </div>
+    </div>
+  )
 }
 
 /**
  * A single error/warning message.
  */
-const Message = (diag: FlatDiagnostic, key: number): JSX.Element => {
+const Message = (diag: FlatDiagnostic, key: number, open: boolean): JSX.Element => {
   const w = diag.is_warning
-  return (<div key={key} className={`flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
-  <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
-  <span className="sr-only">Info</span>
-  <div>
-    <span className="font-semibold">{`${w ? 'Advertencia' : 'Error'}: `}</span> {`${diag.message}`}
-  </div>
-</div>)
+
+  return (
+  <div key={key} className={`overflow-hidden flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
+    <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
+    <span className="sr-only">Info</span>
+    <div className={`min-w-[14rem] ${open ? '' : 'hidden'} `}>
+      <span className={'font-semibold '}>{`${w ? 'Advertencia' : 'Error'}: `}</span>
+      {`${diag.message}`}
+    </div>
+  </div>)
 }
 
 /**
  * The error tray shows errors and warnings about the current plan that come from the validation backend.
  */
 const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[], validating: boolean }): JSX.Element => {
+  const [open, setOpen] = useState(true)
+  const hasError = diagnostics.some(diag => !diag.is_warning)
   // Order diagnostics by putting errors first, then warnings.
   diagnostics.sort((a, b) => {
     if (a.is_warning === b.is_warning) {
@@ -42,13 +50,32 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
       return -1
     }
   })
-  const messageList: JSX.Element[] = diagnostics.map((diag, index) => Message(diag, index))
-  return (<div className="w-80 min-w-[200px] h-[95%] mb-6 overflow-y-auto px-5 py-6 bg-slate-100 border-slate-300 border-2 rounded-lg shadow-lg">
-    <p className="text-xl font-semibold mb-4 text-center">Errores y advertencias</p>
-  <div className="flex flex-col gap-2">
-    {validating ? <Spinner message='Validando...'/> : <>{messageList.length > 0 ? messageList : <NoMessages/>}</>}
-  </div>
-  </div>)
+  const messageList: JSX.Element[] = diagnostics.map((diag, index) => Message(diag, index, open || hasError))
+  return (
+    <div className="h-[95%] flex relative">
+      {!hasError &&
+        <div className="h-28 absolute -left-4 z-10">
+          <button className="h-full bg-slate-100 rounded-l-3xl border-slate-300  border-t-2 border-l-2 text-slate-500 focus:outline-none" onClick={() => setOpen(prev => !prev)}>
+            <svg className={`w-4 h-4 ${hasError || open ? '' : 'transform rotate-180'}`} viewBox="0 0 24 24" fill="currentColor">
+              <path d="M0 0h24v24H0z" fill="none" />
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </button>
+        </div>
+      }
+      <div className={`relative mb-2 overflow-y-auto py-4 bg-slate-100 border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${!hasError ? 'rounded-tl-none' : ''} ${hasError || open ? 'w-80 min-w-[200px] px-5' : 'w-20 px-4'}`}>
+        <div className='flex mb-4 justify-center'>
+          <svg aria-hidden="true" className="flex-shrink-0 inline w-6 h-7" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path>
+          </svg>
+          {(hasError || open) && <p className="whitespace-nowrap ml-1 text-xl font-semibold text-center h-7 overflow-hidden">Errores y Advertencias </p>}
+        </div>
+        <div className="flex flex-col gap-2">
+          {validating ? <Spinner message='Validando...'/> : <>{messageList.length > 0 ? messageList : <NoMessages/>}</>}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default ErrorTray

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -7,7 +7,7 @@ import { Spinner } from '../../components/Spinner'
  */
 const NoMessages = ({ open }: { open: boolean }): JSX.Element => {
   return (
-    <div className="flex p-3 mb-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 " role="alert">
+    <div className="w-fit flex p-3 mb-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 " role="alert">
       <svg aria-hidden="true" className="flex-shrink-0 inline-flex w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
       <span className="sr-only">Info</span>
       <div className={`min-w-[14rem] ml-2 s${open ? '' : 'hidden'} `}>
@@ -24,7 +24,7 @@ const Message = (diag: FlatDiagnostic, key: number, open: boolean): JSX.Element 
   const w = diag.is_warning
 
   return (
-  <div key={key} className={`overflow-hidden flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
+  <div key={key} className={`w-fit flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
     <svg aria-hidden="true" className="flex-shrink-0 inline-flex w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
     <span className="sr-only">Info</span>
     <div className={`min-w-[14rem] ml-2 ${open ? '' : 'hidden'} `}>
@@ -53,8 +53,8 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
   const messageList: JSX.Element[] = diagnostics.map((diag, index) => Message(diag, index, open || hasError))
 
   return (
-      <div className={`h-[95%] z-20 flex flex-col relative border-slate-300 border-2 rounded-lg bg-slate-100 shadow-lg mb-2 overflow-y-auto overflow-x-hidden  py-4 px-3  motion-reduce:transition-none transition-all ${hasError || open ? 'w-80 min-w-[20rem]' : 'min-w-[4.5rem]'}`}>
-        <div className='flex mb-4 mx-3'>
+      <div className={`h-[95%] z-20 flex flex-col relative border-slate-300 border-2 rounded-lg bg-slate-100 shadow-lg mb-2 py-4  motion-reduce:transition-none transition-all ${hasError || open ? 'w-80 min-w-[20rem]' : 'min-w-[4.5rem]'}`}>
+        <div className='flex mb-4 mx-6'>
           <div className='group relative flex'>
             <span className={`fixed z-10 transition-all motion-reduce:transition-none scale-0 ${hasError ? 'group-hover:scale-100' : ''}`}>
               <div className="absolute right-2.5 top-1 w-4 h-4 bg-gray-800 rotate-45 rounded" />
@@ -70,8 +70,8 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
           </div>
           {(hasError || open) && <p className="whitespace-nowrap ml-2 text-xl font-semibold text-center h-7 overflow-hidden">Errores y Advertencias </p>}
         </div>
-        <div className="flex flex-col gap-2 flex-wrap">
-            {validating ? <Spinner message={`${hasError || open ? 'Validando...' : ''}`}/> : <>{messageList.length > 0 ? messageList : <NoMessages open={hasError || open}/>}</>}
+        <div className="h-full flex flex-col gap-2 px-3 overflow-y-auto overflow-x-hidden ">
+            {validating ? <div> <Spinner message={`${hasError || open ? 'Validando...' : ''}`}/></div> : <>{messageList.length > 0 ? messageList : <NoMessages open={hasError || open}/>}</>}
         </div>
       </div>
   )

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -53,17 +53,16 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
   const messageList: JSX.Element[] = diagnostics.map((diag, index) => Message(diag, index, open || hasError))
   return (
     <div className="h-[95%] flex relative">
-      {!hasError &&
-        <div className="h-28 absolute -left-4 z-10">
-          <button className="h-full bg-slate-100 rounded-l-3xl border-slate-300  border-t-2 border-l-2 text-slate-500 focus:outline-none" onClick={() => setOpen(prev => !prev)}>
+      <div className={`h-16 absolute ${hasError ? 'translate-x-0' : '-translate-x-4'} z-10 motion-reduce:transition-none transition-all`}>
+        <button className="h-full bg-slate-100 rounded-l-lg border-slate-300 border-t-2 border-b-2 border-l-2 text-slate-500 focus:outline-none" onClick={() => setOpen(prev => !prev)}>
             <svg className={`w-4 h-4 ${hasError || open ? '' : 'transform rotate-180'}`} viewBox="0 0 24 24" fill="currentColor">
               <path d="M0 0h24v24H0z" fill="none" />
               <path d="M8 5v14l11-7z" />
             </svg>
           </button>
         </div>
-      }
-      <div className={`relative mb-2 overflow-y-auto py-4 bg-slate-100 border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${!hasError ? 'rounded-tl-none' : ''} ${hasError || open ? 'w-80 min-w-[200px] px-5' : 'w-20 px-4'}`}>
+      <div className={` border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${!hasError ? 'rounded-tl-none' : ''} ${hasError || open ? 'w-80 min-w-[200px]' : 'w-20'}`}>
+        <div className={`relative mb-2 overflow-y-auto h-full w-full py-4 rounded-lg  bg-slate-100 z-20 px-4 ${!hasError ? 'rounded-tl-none' : ''}`}>
         <div className='flex mb-4 justify-center'>
           <svg aria-hidden="true" className="flex-shrink-0 inline w-6 h-7" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path>
@@ -73,6 +72,7 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
         <div className="flex flex-col gap-2">
           {validating ? <Spinner message='Validando...'/> : <>{messageList.length > 0 ? messageList : <NoMessages/>}</>}
         </div>
+      </div>
       </div>
     </div>
   )

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -25,9 +25,9 @@ const Message = (diag: FlatDiagnostic, key: number, open: boolean): JSX.Element 
 
   return (
   <div key={key} className={`overflow-hidden flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
-    <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
+    <svg aria-hidden="true" className="flex-shrink-0 inline w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
     <span className="sr-only">Info</span>
-    <div className={`min-w-[14rem] ${open ? '' : 'hidden'} `}>
+    <div className={`min-w-[14rem] ml-2 ${open ? '' : 'hidden'} `}>
       <span className={'font-semibold '}>{`${w ? 'Advertencia' : 'Error'}: `}</span>
       {`${diag.message}`}
     </div>
@@ -52,8 +52,8 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
   })
   const messageList: JSX.Element[] = diagnostics.map((diag, index) => Message(diag, index, open || hasError))
   return (
-    <div className={`h-[95%] flex relative border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${hasError || open ? 'w-80 min-w-[20rem]' : 'w-20'}`}>
-      <div className='relative mb-2 overflow-y-auto h-full w-full py-4 rounded-lg  bg-slate-100 z-20 px-4'>
+    <div className={`h-[95%] flex relative border-slate-300 border-2 rounded-lg shadow-lg motion-reduce:transition-none transition-all ${hasError || open ? 'w-80 min-w-[20rem]' : 'w-[4.5rem]'}`}>
+      <div className='relative mb-2 overflow-y-auto h-full w-full py-4 rounded-lg  bg-slate-100 z-20 px-3'>
         <div className='flex mb-4 mx-3'>
           <div className='group relative flex'>
             <span className={`fixed z-10 transition-all motion-reduce:transition-none scale-0 ${hasError ? 'group-hover:scale-100' : ''}`}>

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -24,7 +24,7 @@ const Message = (diag: FlatDiagnostic, key: number, open: boolean): JSX.Element 
   const w = diag.is_warning
 
   return (
-  <div key={key} className={`motion-reduce:transition-none transition-all  overflow-hidden flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
+  <div key={key} className={`overflow-hidden flex p-3 text-sm rounded-lg border ${w ? 'text-yellow-700 border-yellow-300 bg-yellow-50' : 'text-red-800 border-red-300 bg-red-50'}`} role="alert">
     <svg aria-hidden="true" className="flex-shrink-0 inline-flex w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"></path></svg>
     <span className="sr-only">Info</span>
     <div className={`min-w-[14rem] ml-2 ${open ? '' : 'hidden'} `}>
@@ -70,7 +70,7 @@ const ErrorTray = ({ diagnostics, validating }: { diagnostics: FlatDiagnostic[],
           </div>
           {(hasError || open) && <p className="whitespace-nowrap ml-2 text-xl font-semibold text-center h-7 overflow-hidden">Errores y Advertencias </p>}
         </div>
-        <div className="flex flex-col gap-2 w-fit">
+        <div className="flex flex-col gap-2 flex-wrap">
             {validating ? <Spinner message={`${hasError || open ? 'Validando...' : ''}`}/> : <>{messageList.length > 0 ? messageList : <NoMessages open={hasError || open}/>}</>}
         </div>
       </div>

--- a/frontend/src/pages/planner/Planner.tsx
+++ b/frontend/src/pages/planner/Planner.tsx
@@ -314,8 +314,10 @@ const Planner = (): JSX.Element => {
     // its not ok to use `validatablePlan` directly
     setValidatablePlan(prev => {
       if (prev === null) return null
-      const newClases = prev.classes
-      newClases[semIdx].splice(index, 1)
+      const newClases = [...prev.classes]
+      const newClasesSem = [...prev.classes[semIdx]]
+      newClasesSem.splice(index, 1)
+      newClases[semIdx] = newClasesSem
       while (newClases[newClases.length - 1].length === 0) {
         newClases.pop()
       }
@@ -573,7 +575,7 @@ const Planner = (): JSX.Element => {
       <CourseSelectorDialog equivalence={modalData?.equivalence} open={isModalOpen} onClose={closeModal}/>
       <AlertModal title={popUpAlert.title} desc={popUpAlert.desc} isOpen={popUpAlert.isOpen} close={handlePopUpAlert}/>
       {plannerStatus === 'LOADING' && (
-        <div className="fixed left-0 w-screen h-full z-50 bg-white flex justify-center items-center">
+        <div className="fixed left-0 w-screen h-full z-50 bg-white flex flex-col justify-center items-center">
           <Spinner message='Cargando planificación...' />
         </div>
       )}

--- a/frontend/src/pages/planner/Planner.tsx
+++ b/frontend/src/pages/planner/Planner.tsx
@@ -289,6 +289,7 @@ const Planner = (): JSX.Element => {
       setPlannerStatus(PlannerStatus.VALIDATING)
       try {
         const res = await DefaultService.savePlan(planName, validatablePlan)
+        console.log(res)
         toast.success('Plan guardado exitosamente, redireccionando...', {
           toastId: 'newPlanSaved',
           data: { planId: res.id }

--- a/frontend/src/pages/planner/Planner.tsx
+++ b/frontend/src/pages/planner/Planner.tsx
@@ -330,7 +330,7 @@ const Planner = (): JSX.Element => {
     setValidatablePlan(prev => {
       if (prev === null) return prev
       const dragCourse = prev.classes[drag.semester][drag.index]
-      if (dragCourse.is_concrete === true && drop.semester !== drag.semester && prev.classes[drop.semester].map(course => course.code).includes(dragCourse.code)) {
+      if (dragCourse.is_concrete === true && drop.semester !== drag.semester && drop.semester < prev.classes.length && prev.classes[drop.semester].map(course => course.code).includes(dragCourse.code)) {
         toast.error('No se puede tener dos cursos iguales en un mismo semestre')
         return prev
       }
@@ -344,10 +344,11 @@ const Planner = (): JSX.Element => {
       } else {
         newClasses[drag.semester].splice(drag.index, 1)
       }
+      console.log(newClasses, newClasses[newClasses.length - 1], newClasses[newClasses.length - 1].length === 0)
       while (newClasses[newClasses.length - 1].length === 0) {
         newClasses.pop()
       }
-      return { ...prev, classe: newClasses }
+      return { ...prev, classes: newClasses }
     })
   }, []) // moveCourse should not depend on `validatablePlan`, so that memoing does its work
 

--- a/frontend/src/pages/planner/Planner.tsx
+++ b/frontend/src/pages/planner/Planner.tsx
@@ -289,7 +289,6 @@ const Planner = (): JSX.Element => {
       setPlannerStatus(PlannerStatus.VALIDATING)
       try {
         const res = await DefaultService.savePlan(planName, validatablePlan)
-        console.log(res)
         toast.success('Plan guardado exitosamente, redireccionando...', {
           toastId: 'newPlanSaved',
           data: { planId: res.id }
@@ -572,15 +571,14 @@ const Planner = (): JSX.Element => {
     }
   }, [validatablePlan])
   return (
-    <div className={`w-full h-full p-3 flex flex-grow overflow-hidden flex-row ${(plannerStatus !== 'ERROR' && plannerStatus !== 'READY') ? 'cursor-wait' : ''}`}>
+    <div className={`w-full relative h-full p-3 flex flex-grow overflow-hidden flex-row ${(plannerStatus !== 'ERROR' && plannerStatus !== 'READY') ? 'cursor-wait' : ''}`}>
       <DebugGraph validatablePlan={validatablePlan} />
       <CourseSelectorDialog equivalence={modalData?.equivalence} open={isModalOpen} onClose={closeModal}/>
       <AlertModal title={popUpAlert.title} desc={popUpAlert.desc} isOpen={popUpAlert.isOpen} close={handlePopUpAlert}/>
-      {plannerStatus === 'LOADING' && (
-        <div className="fixed left-0 w-screen h-full z-50 bg-white flex flex-col justify-center items-center">
+
+        <div className="absolute p-3 w-screen h-full z-50 flex flex-col justify-center items-center">
           <Spinner message='Cargando planificación...' />
         </div>
-      )}
 
       {plannerStatus === 'ERROR'
         ? (<div className={'w-full h-full flex flex-col justify-center items-center'}>

--- a/frontend/src/pages/planner/Planner.tsx
+++ b/frontend/src/pages/planner/Planner.tsx
@@ -575,10 +575,11 @@ const Planner = (): JSX.Element => {
       <DebugGraph validatablePlan={validatablePlan} />
       <CourseSelectorDialog equivalence={modalData?.equivalence} open={isModalOpen} onClose={closeModal}/>
       <AlertModal title={popUpAlert.title} desc={popUpAlert.desc} isOpen={popUpAlert.isOpen} close={handlePopUpAlert}/>
-
-        <div className="absolute p-3 w-screen h-full z-50 flex flex-col justify-center items-center">
+      {plannerStatus === 'LOADING' &&
+        <div className="absolute p-3 w-screen h-full z-50 bg-white flex flex-col justify-center items-center">
           <Spinner message='Cargando planificación...' />
         </div>
+      }
 
       {plannerStatus === 'ERROR'
         ? (<div className={'w-full h-full flex flex-col justify-center items-center'}>

--- a/frontend/src/pages/planner/planBoard/CourseCard.tsx
+++ b/frontend/src/pages/planner/planBoard/CourseCard.tsx
@@ -153,11 +153,11 @@ const CourseCard = ({ semester, index, cardData, isDragging, moveCourse, remCour
   )
 }
 
-const Card = ({ semester, index, courseBlock, cardData, hasEquivalence, openSelector, remCourse, hasWarning, hasError }: CardProps): JSX.Element => {
+const Card = memo(function _Card ({ semester, index, courseBlock, cardData, hasEquivalence, openSelector, remCourse, hasWarning, hasError }: CardProps): JSX.Element {
   const authState = useAuth()
   const conditionPassed = authState?.passed?.[cardData.semester]?.find(o => o.code === cardData.code) !== undefined
   const blockId = BlockInitials(courseBlock)
-  const editIcon = blockId === 'FG' ? editWhiteIcon : editBlackIcon
+  const editIcon = (blockId === 'FG') ? editWhiteIcon : editBlackIcon
 
   // Turns out animations are a big source of lag
   const allowAnimations = true && blockId !== 'FG'
@@ -187,6 +187,6 @@ const Card = ({ semester, index, courseBlock, cardData, hasEquivalence, openSele
       </span> }
   </div>
   )
-}
+})
 
 export default memo(CourseCard, deepEqual)


### PR DESCRIPTION
## Que se implementa?
Ahora se puede minimizar la bandeja de errores y advertencias solo cuando no hay ningún error. Al final me convenci por lo simple y lo deje a traves del tipico boton de 3 lineas de las sidebars.
Está implementado de manera que puedas seguir viendo los iconos de las alertas, así como el icono de carga, (pero este sin mensaje al estar validando). También aproveché para corregir el problema de que los selectores de currículos se estaban renderizando debajo de la bandeja de errores.
## Que falta?
Se necesita alguna forma de identificar rápidamente el curso del error mostrado en la bandeja. Esto quedará para otra rama, ya que requiere su propia lógica. Como idea, estaba pensando en hacer que al hacer hover sobre el error en la bandeja, se "oscurezca" la pantalla excepto el curso asignado. Habría que probar cómo se ve esto. Esto aun le faltaria una forma de identificar rapido los ramos requisitos faltante y esas cosas eso si.