### PR TITLE
Moderador crea, ve, modifica y elimina planes de un usuario (PAN-31 PAN-32)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -111,7 +111,7 @@ async def authenticate(next: Optional[str] = None, ticket: Optional[str] = None)
 
 
 @app.get("/auth/check")
-async def check_auth(user_data: UserKey = Depends(require_authentication)):
+async def check_auth(user: UserKey = Depends(require_authentication)):
     """
     Request succeeds if user authentication was successful.
     Otherwise, the request fails with 401 Unauthorized.
@@ -120,7 +120,7 @@ async def check_auth(user_data: UserKey = Depends(require_authentication)):
 
 
 @app.get("/auth/check/mod")
-async def check_mod(user_data: ModKey = Depends(require_mod_auth)):
+async def check_mod(user: ModKey = Depends(require_mod_auth)):
     """
     Request succeeds if user authentication and mod authorization were successful.
     Otherwise, the request fails with 401 Unauthorized or 403 Forbidden.
@@ -129,7 +129,7 @@ async def check_mod(user_data: ModKey = Depends(require_mod_auth)):
 
 
 @app.get("/auth/check/admin")
-async def check_admin(user_data: AdminKey = Depends(require_admin_auth)):
+async def check_admin(user: AdminKey = Depends(require_admin_auth)):
     """
     Request succeeds if user authentication and admin authorization were successful.
     Otherwise, the request fails with 401 Unauthorized or 403 Forbidden.
@@ -138,7 +138,7 @@ async def check_admin(user_data: AdminKey = Depends(require_admin_auth)):
 
 
 @app.get("/auth/mod", response_model=list[AccessLevelOverview])
-async def view_mods(user_data: AdminKey = Depends(require_admin_auth)):
+async def view_mods(user: AdminKey = Depends(require_admin_auth)):
     """
     Show a list of all current mods with username and RUT. Up to 50 records.
     """
@@ -160,7 +160,7 @@ async def view_mods(user_data: AdminKey = Depends(require_admin_auth)):
 
 
 @app.post("/auth/mod")
-async def add_mod(rut: str, user_data: AdminKey = Depends(require_admin_auth)):
+async def add_mod(rut: str, user: AdminKey = Depends(require_admin_auth)):
     """
     Give mod access to a user with the specified RUT.
     """
@@ -181,7 +181,7 @@ async def add_mod(rut: str, user_data: AdminKey = Depends(require_admin_auth)):
 
 
 @app.delete("/auth/mod")
-async def remove_mod(rut: str, user_data: AdminKey = Depends(require_admin_auth)):
+async def remove_mod(rut: str, user: AdminKey = Depends(require_admin_auth)):
     """
     Remove mod access from a user with the specified RUT.
 
@@ -364,7 +364,7 @@ async def rebuild_validation_rules():
 
 
 @app.get("/plan/empty_for", response_model=ValidatablePlan)
-async def empty_plan_for_user(user_data: UserKey = Depends(require_authentication)):
+async def empty_plan_for_user(user: UserKey = Depends(require_authentication)):
     """
     Generate an empty plan using the current user as context.
     For example, the created plan includes all passed courses, uses the curriculum
@@ -373,13 +373,12 @@ async def empty_plan_for_user(user_data: UserKey = Depends(require_authenticatio
 
     (Currently this is equivalent to `empty_guest_plan()` until we get user data)
     """
-    return await generate_empty_plan(user_data)
+    return await generate_empty_plan(user)
 
 
 @app.get("/plan/empty_for_any", response_model=ValidatablePlan)
 async def empty_plan_for_any_user(
-    user_rut: str,
-    user_data: ModKey = Depends(require_mod_auth),
+    user_rut: str, user: ModKey = Depends(require_mod_auth)
 ):
     """
     Same functionality as `empty_plan_for_user`, but works for any user identified by
@@ -408,8 +407,7 @@ async def validate_guest_plan(plan: ValidatablePlan):
 
 @app.post("/plan/validate_for", response_model=FlatValidationResult)
 async def validate_plan_for_user(
-    plan: ValidatablePlan,
-    user: UserKey = Depends(require_authentication),
+    plan: ValidatablePlan, user: UserKey = Depends(require_authentication)
 ):
     """
     Validate a plan, generating diagnostics.
@@ -421,9 +419,7 @@ async def validate_plan_for_user(
 
 @app.post("/plan/validate_for_any", response_model=FlatValidationResult)
 async def validate_plan_for_any_user(
-    plan: ValidatablePlan,
-    user_rut: str,
-    user: ModKey = Depends(require_mod_auth),
+    plan: ValidatablePlan, user_rut: str, user: ModKey = Depends(require_mod_auth)
 ):
     """
     Same functionality as `validate_plan_for_user`, but works for any user identified by
@@ -458,9 +454,7 @@ async def generate_plan(passed: ValidatablePlan):
 
 @app.post("/plan/storage", response_model=PlanView)
 async def save_plan(
-    name: str,
-    plan: ValidatablePlan,
-    user: UserKey = Depends(require_authentication),
+    name: str, plan: ValidatablePlan, user: UserKey = Depends(require_authentication)
 ) -> PlanView:
     """
     Save a plan with the given name in the storage of the current user.
@@ -501,8 +495,7 @@ async def read_plans(
 
 @app.get("/plan/storage/any", response_model=list[LowDetailPlanView])
 async def read_any_plans(
-    user_rut: str,
-    user: ModKey = Depends(require_mod_auth),
+    user_rut: str, user: ModKey = Depends(require_mod_auth)
 ) -> list[LowDetailPlanView]:
     """
     Same functionality as `read_plans`, but works for any user identified by
@@ -514,8 +507,7 @@ async def read_any_plans(
 
 @app.get("/plan/storage/details", response_model=PlanView)
 async def read_plan(
-    plan_id: str,
-    user: UserKey = Depends(require_authentication),
+    plan_id: str, user: UserKey = Depends(require_authentication)
 ) -> PlanView:
     """
     Fetch the plan details for a given plan id.
@@ -526,8 +518,7 @@ async def read_plan(
 
 @app.get("/plan/storage/any/details", response_model=PlanView)
 async def read_any_plan(
-    plan_id: str,
-    user: ModKey = Depends(require_mod_auth),
+    plan_id: str, user: ModKey = Depends(require_mod_auth)
 ) -> PlanView:
     """
     Same functionality as `read_plan`, but works for any plan of any user
@@ -553,9 +544,7 @@ async def update_plan(
 
 @app.put("/plan/storage/any", response_model=PlanView)
 async def update_any_plan(
-    plan_id: str,
-    new_plan: ValidatablePlan,
-    user: ModKey = Depends(require_mod_auth),
+    plan_id: str, new_plan: ValidatablePlan, user: ModKey = Depends(require_mod_auth)
 ) -> PlanView:
     """
     Same functionality as `update_plan`, but works for any plan of any user
@@ -613,8 +602,7 @@ async def update_any_plan_metadata(
 
 @app.delete("/plan/storage", response_model=PlanView)
 async def delete_plan(
-    plan_id: str,
-    user: UserKey = Depends(require_authentication),
+    plan_id: str, user: UserKey = Depends(require_authentication)
 ) -> PlanView:
     """
     Deletes a plan by ID.
@@ -626,8 +614,7 @@ async def delete_plan(
 
 @app.delete("/plan/storage/any", response_model=PlanView)
 async def delete_any_plan(
-    plan_id: str,
-    user: ModKey = Depends(require_mod_auth),
+    plan_id: str, user: ModKey = Depends(require_mod_auth)
 ) -> PlanView:
     """
     Same functionality as `delete_plan`, but works for any plan of any user

--- a/backend/app/plan/storage.py
+++ b/backend/app/plan/storage.py
@@ -71,9 +71,11 @@ class LowDetailPlanView(BaseModel):
         )
 
 
-async def authorize_plan_access(user: UserKey, plan_id: str) -> DbPlan:
+async def authorize_plan_access(
+    user: UserKey, plan_id: str, mod_access: bool
+) -> DbPlan:
     plan = await DbPlan.prisma().find_unique(where={"id": plan_id})
-    if not plan or plan.user_rut != user.rut:
+    if not plan or (not mod_access and plan.user_rut != user.rut):
         raise HTTPException(status_code=404, detail="Plan not found in user storage")
     return plan
 
@@ -97,8 +99,10 @@ async def store_plan(plan_name: str, user: UserKey, plan: ValidatablePlan) -> Pl
     return PlanView.from_db(stored_plan)
 
 
-async def get_plan_details(user: UserKey, plan_id: str) -> PlanView:
-    plan = await authorize_plan_access(user, plan_id)
+async def get_plan_details(
+    user: UserKey, plan_id: str, mod_access: bool = False
+) -> PlanView:
+    plan = await authorize_plan_access(user, plan_id, mod_access)
     return PlanView.from_db(plan)
 
 
@@ -118,9 +122,9 @@ async def get_user_plans(user: UserKey) -> list[LowDetailPlanView]:
 
 
 async def modify_validatable_plan(
-    user: UserKey, plan_id: str, new_plan: ValidatablePlan
+    user: UserKey, plan_id: str, new_plan: ValidatablePlan, mod_access: bool = False
 ) -> PlanView:
-    await authorize_plan_access(user, plan_id)
+    await authorize_plan_access(user, plan_id, mod_access)
 
     updated_plan = await DbPlan.prisma().update(
         where={"id": plan_id}, data={"validatable_plan": Json(new_plan.json())}
@@ -136,8 +140,9 @@ async def modify_plan_metadata(
     plan_id: str,
     set_name: Union[str, None],
     set_favorite: Union[bool, None],
+    mod_access: bool = False,
 ) -> PlanView:
-    await authorize_plan_access(user, plan_id)
+    await authorize_plan_access(user, plan_id, mod_access)
 
     if set_name is not None:
         return await _rename_plan(plan_id=plan_id, new_name=set_name)
@@ -208,8 +213,10 @@ async def _set_favorite_plan(user: UserKey, plan_id: str, favorite: bool):
     return PlanView.from_db(updated_plan)
 
 
-async def remove_plan(user: UserKey, plan_id: str) -> PlanView:
-    await authorize_plan_access(user, plan_id)
+async def remove_plan(
+    user: UserKey, plan_id: str, mod_access: bool = False
+) -> PlanView:
+    await authorize_plan_access(user, plan_id, mod_access)
 
     deleted_plan = await DbPlan.prisma().delete(where={"id": plan_id})
     # Must be true because access was authorized

--- a/backend/app/plan/storage.py
+++ b/backend/app/plan/storage.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from ..user.auth import UserKey
+from ..user.key import UserKey, ModKey
 from fastapi import HTTPException
 from prisma import Json
 from prisma.models import Plan as DbPlan
@@ -72,8 +72,9 @@ class LowDetailPlanView(BaseModel):
 
 
 async def authorize_plan_access(
-    user: UserKey, plan_id: str, mod_access: bool
+    user: UserKey, plan_id: str, try_mod_access: bool
 ) -> DbPlan:
+    mod_access = try_mod_access and isinstance(user, ModKey)
     plan = await DbPlan.prisma().find_unique(where={"id": plan_id})
     if not plan or (not mod_access and plan.user_rut != user.rut):
         raise HTTPException(status_code=404, detail="Plan not found in user storage")

--- a/backend/app/user/key.py
+++ b/backend/app/user/key.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass, field
-from typing import Optional, Literal
+from dataclasses import dataclass
 
 
 @dataclass
@@ -13,33 +12,44 @@ class UserKey:
 
     Example:
     << user = UserKey(username="usuario", rut="12345678-9")
-    >> UserKey(username='usuario', rut='12345678-9', is_admin=False, is_mod=False)
+    >> UserKey(username='usuario', rut='12345678-9')
     """
 
     username: str
     rut: str
-    is_admin: Optional[bool] = field(init=False, default=False)
-    is_mod: Optional[bool] = field(init=False, default=False)
 
 
 class ModKey(UserKey):
     """
+    This key should only be constructed from `require_mod_auth`, which does the
+    necessary authorization.
+    Because this key can only come from a call to `require_mod_auth`, holding an
+    instance of this type is intended to mean "I have mod authorization".
+    Therefore, any function requiring `ModKey` as an argument means "using this
+    function requires mod authorization".
+
     Example:
     << mod = ModKey(username="moderador", rut="12345678-9")
-    >> ModKey(username='moderador', rut='12345678-9', is_admin=False, is_mod=True)
+    >> ModKey(username='moderador', rut='12345678-9')
     """
 
-    is_mod: Literal[True] = True
-
-    def __post_init__(self):
-        self.is_admin = False
+    def as_any_user(self, user_rut: str) -> UserKey:
+        """
+        Moderators can access the resources of any user.
+        """
+        return UserKey("", user_rut)
 
 
 class AdminKey(ModKey):
     """
+    This key should only be constructed from `require_admin_auth`, which does the
+    necessary authorization.
+    Because this key can only come from a call to `require_admin_auth`, holding an
+    instance of this type is intended to mean "I have admin authorization".
+    Therefore, any function requiring `AdminKey` as an argument means "using this
+    function requires admin authorization".
+
     Example:
     << admin = AdminKey(username="administrador", rut="12345678-9")
-    >> AdminKey(username='administrador', rut='12345678-9', is_admin=True, is_mod=True)
+    >> AdminKey(username='administrador', rut='12345678-9')
     """
-
-    is_admin: Literal[True] = True

--- a/frontend/src/client/services/DefaultService.ts
+++ b/frontend/src/client/services/DefaultService.ts
@@ -338,6 +338,30 @@ export class DefaultService {
     }
 
     /**
+     * Empty Plan For Any User
+     * Same functionality as `empty_plan_for_user`, but works for any user identified by
+     * their RUT with `user_rut`.
+     * Moderator access is required.
+     * @param userRut
+     * @returns ValidatablePlan Successful Response
+     * @throws ApiError
+     */
+    public static emptyPlanForAnyUser(
+        userRut: string,
+    ): CancelablePromise<ValidatablePlan> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/plan/empty_for_any',
+            query: {
+                'user_rut': userRut,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
      * Empty Guest Plan
      * Generates a generic empty plan with no user context, using the latest curriculum
      * version.
@@ -386,6 +410,34 @@ export class DefaultService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/plan/validate_for',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Validate Plan For Any User
+     * Same functionality as `validate_plan_for_user`, but works for any user identified by
+     * their RUT with `user_rut`.
+     * Moderator access is required.
+     * @param userRut
+     * @param requestBody
+     * @returns FlatValidationResult Successful Response
+     * @throws ApiError
+     */
+    public static validatePlanForAnyUser(
+        userRut: string,
+        requestBody: ValidatablePlan,
+    ): CancelablePromise<FlatValidationResult> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/plan/validate_for_any',
+            query: {
+                'user_rut': userRut,
+            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {
@@ -485,7 +537,7 @@ export class DefaultService {
     /**
      * Save Plan
      * Save a plan with the given name in the storage of the current user.
-     * Fails if the user is not logged  in.
+     * Fails if the user is not logged in.
      * @param name
      * @param requestBody
      * @returns PlanView Successful Response
@@ -534,6 +586,115 @@ export class DefaultService {
     }
 
     /**
+     * Read Any Plans
+     * Same functionality as `read_plans`, but works for any user identified by
+     * their RUT with `user_rut`.
+     * Moderator access is required.
+     * @param userRut
+     * @returns LowDetailPlanView Successful Response
+     * @throws ApiError
+     */
+    public static readAnyPlans(
+        userRut: string,
+    ): CancelablePromise<Array<LowDetailPlanView>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/plan/storage/any',
+            query: {
+                'user_rut': userRut,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Update Any Plan
+     * Same functionality as `update_plan`, but works for any plan of any user
+     * identified by their RUT.
+     * Moderator access is required.
+     * @param planId
+     * @param requestBody
+     * @returns PlanView Successful Response
+     * @throws ApiError
+     */
+    public static updateAnyPlan(
+        planId: string,
+        requestBody: ValidatablePlan,
+    ): CancelablePromise<PlanView> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/plan/storage/any',
+            query: {
+                'plan_id': planId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Save Any Plan
+     * Same functionality as `save_plan`, but works for any user identified by
+     * their RUT with `user_rut`.
+     * Moderator access is required.
+     * All `/plan/storage/any` endpoints (and sub-resources) should require
+     * moderator access.
+     * @param name
+     * @param userRut
+     * @param requestBody
+     * @returns PlanView Successful Response
+     * @throws ApiError
+     */
+    public static saveAnyPlan(
+        name: string,
+        userRut: string,
+        requestBody: ValidatablePlan,
+    ): CancelablePromise<PlanView> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/plan/storage/any',
+            query: {
+                'name': name,
+                'user_rut': userRut,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Delete Any Plan
+     * Same functionality as `delete_plan`, but works for any plan of any user
+     * identified by their RUT.
+     * Moderator access is required.
+     * @param planId
+     * @returns PlanView Successful Response
+     * @throws ApiError
+     */
+    public static deleteAnyPlan(
+        planId: string,
+    ): CancelablePromise<PlanView> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/plan/storage/any',
+            query: {
+                'plan_id': planId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
      * Read Plan
      * Fetch the plan details for a given plan id.
      * Requires the current user to be the plan owner.
@@ -547,6 +708,30 @@ export class DefaultService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/plan/storage/details',
+            query: {
+                'plan_id': planId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Read Any Plan
+     * Same functionality as `read_plan`, but works for any plan of any user
+     * identified by their RUT.
+     * Moderator access is required.
+     * @param planId
+     * @returns PlanView Successful Response
+     * @throws ApiError
+     */
+    public static readAnyPlan(
+        planId: string,
+    ): CancelablePromise<PlanView> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/plan/storage/any/details',
             query: {
                 'plan_id': planId,
             },
@@ -576,6 +761,36 @@ export class DefaultService {
         return __request(OpenAPI, {
             method: 'PUT',
             url: '/plan/storage/metadata',
+            query: {
+                'plan_id': planId,
+                'set_name': setName,
+                'set_favorite': setFavorite,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Update Any Plan Metadata
+     * Same functionality as `update_plan_metadata`, but works for any plan of any user
+     * identified by their RUT.
+     * Moderator access is required.
+     * @param planId
+     * @param setName
+     * @param setFavorite
+     * @returns PlanView Successful Response
+     * @throws ApiError
+     */
+    public static updateAnyPlanMetadata(
+        planId: string,
+        setName?: string,
+        setFavorite?: boolean,
+    ): CancelablePromise<PlanView> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/plan/storage/any/metadata',
             query: {
                 'plan_id': planId,
                 'set_name': setName,


### PR DESCRIPTION
### ¿Qué se implementa?
- endpoint `/plan/storage/any` (y sub-recursos) que permiten a un mod/admin guardar, ver, modificar y eliminar planificaciones de un usuario.
- endpoints `/plan/empty_for_any` y `/plan/validate_for_any` que permiten a un mod/admin crear y validar planificaciones basadas en un usuario específico.
- algunos refactors chicos para mejor consistencia.

### Notas
- A primera vista esta implementación puede parecer muy repetitiva de código, ya que duplica varios endpoints para entregar capacidades de mayor acceso. Sin embargo, creo que puede ser bueno mantener estos dos mundos separados (los `storage` vs los `storage/any`) ya que es un caso especial- y a la vez potencialmente peligroso -como para tenerlo acoplado a los endpoints que utilizan todos los usuarios. Lo bueno de hacerlo así es que todo el control de autorizaciones se maneja desde el módulo `auth` (e.g. función `require_mod_auth`).