### PR TITLE
docs: separate install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ El proyecto está configurado para ser desarrollado en [Visual Studio Code](http
 #### Desarrollo en GitHub Codespaces
 
 Codespaces es un servicio de GitHub que permite correr VSCode en la nube.
-Provee una cantidad limitada de horas de uso, que puede ser [expandida activando la cuenta Pro gratis a esrtudiantes](https://education.github.com/discount_requests/application).
+Provee una cantidad limitada de horas de uso, que puede ser [expandida activando la cuenta Pro gratis a estudiantes](https://education.github.com/discount_requests/application).
 
 - Instala la extensión de [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
 - Crea o abre un Codespace desde el botón en la esquina superior derecha de este repositorio (o desde el menú de VSCode). Si no lo has creado, ingresa `open-source-uc/planner` como el repositorio a abrir.
@@ -65,8 +65,8 @@ Para realizar acciones sobre el repositorio (migraciones, generación de código
 - el task runner de VSCode (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> -> _"Tasks: Run Task"_).
 - `just` en la linea de comandos. Para ver comandos disponibles, corre `just` desde cualquier carpeta.
 
-Es important que cuando:
-- Cambias la extructura de la API, corras la tarea _"Generate client"_ (también disponible en modo watch).
+Es importante que cuando:
+- Cambias la estructura de la API, corras la tarea _"Generate client"_ (también disponible en modo watch).
 - Cambies el esquema de la base de datos, corras la tarea _"Create/apply migrations"_ para que los cambios se reflejen en la base de datos.
 
 Para realizar contribuciones, revisa [contributing.md](contributing.md).

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
 </p>
 
 <p align="center">
-  <a href="#Descripción">Descripción</a> •
-  <a href="#Uso">Uso</a> •
-  <a href="#Contribuir">Contribuir</a> •
-  <a href="#Equipo">Equipo</a> •
-  <a href="#Licencia">Licencia</a>
+  <a href="#descripción">Descripción</a> •
+  <a href="#instalación-y-desarrollo">Instalación</a> •
+  <a href="#equipo">Equipo</a> •
+  <a href="#licencia">Licencia</a>
 </p>
 
 <h4 align="center">
@@ -28,10 +27,6 @@ Este es el hogar para el desarrollo del nuevo Planner de Ingeniería UC, hecho p
 Tras varios años en ideación, este proyecto se lanzó como [una propuesta conjunta](https://drive.google.com/file/d/1IxAJ8cCzDkayPwnju5kgc2oKc7g9fvwf/view) entre la Consejería Académica de Ingeniería y Open Source UC, con el propósito de reemplazar el [actual planner de Ingeniería](https://planner.ing.puc.cl/). La propuesta, tras ser aprobada por la Escuela de Ingeniería, dió comienzo al proyecto en modalidad de marcha blanca. A principios del 2023, y con un MVP listo, la Dirección de Pregrado oficialmente aprobó la continuación del desarrollo del proyecto.
 
 ## Instalación y desarrollo
-
-La forma óptima de correr el proyecto, sin tener que instalar todas las dependencias, es utilizar el [development container](https://containers.dev/) para VSCode. El contenedor viene completamente configurado y listo para correr el proyecto.
-
-### Pasos sugeridos
 
 El proyecto está configurado para ser desarrollado en [Visual Studio Code](https://code.visualstudio.com/) con [Dev Containers](https://code.visualstudio.com/docs/remote/containers). Puedes [instalar VSCode aquí](https://code.visualstudio.com/download). Existen 2 maneras de correr Dev Containers: GitHub Codespaces y localmente.
 
@@ -72,6 +67,13 @@ Es important que cuando:
 - Cambias la extructura de la API, corras la tarea _"Generate client"_ (también disponible en modo watch).
 - Cambies el esquema de la base de datos, corras la tarea _"Create/apply migrations"_ para que los cambios se reflejen en la base de datos.
 
+Para realizar contribuciones, revisa [contributing.md](contributing.md).
+
+### Bug Reports & Feature Requests
+
+> **Nota:** Este proyecto usa [Linear](https://linear.app/) para rastrear el progreso del proyecto. Por ahora, el Linear no es público, pero de todas formas se revisan los issues y features creados en GitHub.
+
+La app aún está en una etapa muy temprana del desarrollo por lo que podrían haber cosas que no funcionan correctamente o difieren de la documentación, por lo que cualquier lector siéntase libre a colaborar :rocket:. Toda ayuda es bienvenida :)
 
 ## Mocks
 
@@ -79,22 +81,6 @@ El proyecto se integra con dos servicios externos: SIDING (para acceder a mallas
 
 - Para SIDING se provee un mock que se activa automáticamente en ausencia de credenciales. El mock es limitado, y solo permite probar algunas combinaciones de malla.
 - Para CAS, se provee el servicio `cas-server-mock` que corre automáticamente junto a la app. Las cuentas de usuario disponibles son configurables en el archivo `data/cas-mock-users.json`.
-
-<p align="right">(<a href="#readme-top">volver arriba</a>)</p>
-
-## Contribuir
-
-### Workflow
-
-> El workflow es abrir PR a main -> Revisar preview y checks -> Asignar reviewers -> Aprobación -> Merge a main
-
-La información detallada sobre cómo contribuir se puede encontrar en [contributing.md](contributing.md).
-
-### Bug Reports & Feature Requests
-
-> **Nota:** Este proyecto usa [Linear](https://linear.app/) para rastrear el progreso del proyecto. Por ahora, el Linear no es público, pero de todas formas se revisan los issues y features creados en GitHub.
-
-La app aún está en una etapa muy temprana del desarrollo por lo que podrían haber cosas que no funcionan correctamente o difieren de la documentación, por lo que cualquier lector siéntase libre a colaborar :rocket:. Toda ayuda es bienvenida :)
 
 ## Equipo
 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,52 @@ La forma óptima de correr el proyecto, sin tener que instalar todas las depende
 
 ### Pasos sugeridos
 
-1. Instala [Visual Studio Code](https://code.visualstudio.com/) y [Docker](https://www.docker.com/). En VSCode, instala la extensión [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
-   - También puedes abrir este repositorio con [GitHub Codespaces](https://github.com/features/codespaces). Esto no requiere configuración.
-2. Al abrir el proyecto en VSCode, la extensión Dev Containers debería aparecer un _pop up_ con la opción de "Reabrir en contenedor".
-3. Espera a que se corra la tarea de inicio `just init`. Esto instala las depedencias y crea archivos como `.env` y `cas-mock-users.json`, que son necesarios para correr el proyecto.
-   - El proyecto se integra con dos servicios externos: SIDING (para acceder a mallas y datos de estudiantes) y CAS (para el login UC). Ambos son configurables por medio de variables de entorno.
-   - Se proveen mocks para ambos servicios en caso de no tener credenciales para acceder a ellos.
-   - Para SIDING se provee un mock que se activa automáticamente en ausencia de credenciales. El mock es limitado, y solo permite probar algunas combinaciones de malla.
-   - Para CAS, se provee el servicio `cas-server-mock` que corre automáticamente junto a la app. Las cuentas de usuario disponibles son configurables en el archivo `data/cas-mock-users.json`.
-4. En la sección "Run and Debug" de VSCode aparecerán acciones para correr cada servicio de la app por separado, o todos al mismo tiempo (`Launch all 🚀`).
-   - Adicional a esto, se proveen tareas para distintas acciones de utilidad, como resetear   migrar la base de datos, generar el cliente de la API, abrir [Prisma Studio](https://www.prisma.io/studio), etc. 
-   - Puedes ver las tareas disponibles con el comando `"Tasks: Run Task"` (Ctrl/Cmd + Shift + P).
-   - También se dispone de un [task runner](https://github.com/casey/just) en la linea de comandos. Para ver comandos disponibles, corre `just` desde cualquier carpeta.
+El proyecto está configurado para ser desarrollado en [Visual Studio Code](https://code.visualstudio.com/) con [Dev Containers](https://code.visualstudio.com/docs/remote/containers). Puedes [instalar VSCode aquí](https://code.visualstudio.com/download). Existen 2 maneras de correr Dev Containers: GitHub Codespaces y localmente.
 
-Una vez abierto, todos los cambios en el código debiesen reflejarse automáticamente en tu navegador, sin necesidad de recargar la página.
+#### Desarrollo en GitHub Codespaces
 
-Hay dos excepciones a esto: cambios en la estructura de la API y cambios en el esquema de la base de datos. En el primer caso, debes correr la tarea "Generate client" (también disponible en modo watch). En el segundo caso, debes correr la tarea "Create/apply migrations" para que los cambios se reflejen en la base de datos.
+Codespaces es un servicio de GitHub que permite correr VSCode en la nube.
+Provee una cantidad limitada de horas de uso, que puede ser [expandida activando la cuenta Pro gratis a esrtudiantes](https://education.github.com/discount_requests/application).
+
+- Instala la extensión de [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
+- Crea o abre un Codespace desde el botón en la esquina superior derecha de este repositorio (o desde el menú de VSCode). Si no lo has creado, ingresa `open-source-uc/planner` como el repositorio a abrir.
+
+Sigue en la sección [Desarrollo general](#desarrollo-general).
+
+### Desarrollo local
+
+- Instala [Docker](https://www.docker.com/). Asegurate que esté corriendo.
+- Instala la extensión [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+- Clona este repositorio y abre el proyecto en VSCode.
+- Corre el comando `Dev Containers: Open Folder in Container` o has click en el popup que saldrá al abrir el proyecto.
+
+Sigue en la sección [Desarrollo general](#desarrollo-general).
+
+### Desarrollo general
+
+- El Dev Container correrá automaticamente el setup necesario con `just init`. Espera que termine para continuar.
+- Utiliza `Run and Debug` de VSCode con `Launch all 🚀` para correr todos los servicios al mismo tiempo. Espera que el backend (que puedes inspeccionar en `Python Debug Console`) termine de correr para continuar (cuando se muestre _"Aplication startup complete"_).
+
+Una vez listo, podrás entrar a la app en [http://localhost:3000](http://localhost:3000) 🎉
+
+Necesitaras un nombre de usuario para acceder a CAS. Puedes acceder con `testuser` o con otros usuarios definidos en `cas-mock-users.json`. 
+
+
+Para realizar acciones sobre el repositorio (migraciones, generación de código, etc) puedes usar:
+- el task runner de VSCode (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> -> _"Tasks: Run Task"_).
+- `just` en la linea de comandos. Para ver comandos disponibles, corre `just` desde cualquier carpeta.
+
+Es important que cuando:
+- Cambias la extructura de la API, corras la tarea _"Generate client"_ (también disponible en modo watch).
+- Cambies el esquema de la base de datos, corras la tarea _"Create/apply migrations"_ para que los cambios se reflejen en la base de datos.
+
+
+## Mocks
+
+El proyecto se integra con dos servicios externos: SIDING (para acceder a mallas y datos de estudiantes) y CAS (para el login UC). Ambos son configurables por medio de variables de entorno, y se proveen mocks para ambos servicios en caso de no tener credenciales para acceder a ellos.
+
+- Para SIDING se provee un mock que se activa automáticamente en ausencia de credenciales. El mock es limitado, y solo permite probar algunas combinaciones de malla.
+- Para CAS, se provee el servicio `cas-server-mock` que corre automáticamente junto a la app. Las cuentas de usuario disponibles son configurables en el archivo `data/cas-mock-users.json`.
 
 <p align="right">(<a href="#readme-top">volver arriba</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Provee una cantidad limitada de horas de uso, que puede ser [expandida activando
 
 Sigue en la sección [Desarrollo general](#desarrollo-general).
 
+- Una vez terminado de desarrollar, [detén el Codespace](https://docs.github.com/es/codespaces/developing-in-codespaces/stopping-and-starting-a-codespace) para no consumir horas de uso. También puedes usar un [timeout para que se detenga automáticamente](https://docs.github.com/es/codespaces/customizing-your-codespace/setting-your-timeout-period-for-github-codespaces).
+
 ### Desarrollo local
 
 - Instala [Docker](https://www.docker.com/). Asegurate que esté corriendo.

--- a/contributing.md
+++ b/contributing.md
@@ -1,92 +1,13 @@
 # Contributing
 
+De partida, muchas gracias por contribuir al proyecto 🚀
+
 ## Workflow (Flujo de trabajo)
 
-1. (Opcional) Discutir tu propuesta previamente creando una issue.
-2. Hacer un _fork_ del repositorio para hacer tus cambios, o si tienes los permisos, crear una nueva branch bajo el mismo repositorio.
-   <details><summary>Si ya tienes un fork, debes sincronizar tu repositorio con upstream:</summary>
-   <ul>
-    <li>Hacer un pull request y merge desde la branch `development` de este repositorio hacia `development` de tu fork</li>
-    O
-    
-    <li>Desde github, usar "fetch upstream" y "fetch and merge" para hacer lo mismo pero con menos pasos</li>
-    </ul>
-</details>
-
-3. Crear una branch a partir de la branch `development`, en lo posible con un nombre significativo, ej `add-project-images`.
-4. Crear un Pull Request (PR) a `development`, manteniéndolo como "borrador" (draft) hasta que esté listo para ser revisado por un miembro del equipo.
-5. Explicar brevemente los cambios, siguiendo el formato de Pull Requests, especificando posibles problemas o puntos de discusión.
-6. Solicitar una revisión de pares (_review_) a uno de los integrantes del equipo del proyecto (los encuentras en la seccion de Maintainers del readme). Idealmente el revisor debe ser alguien relacionado con el área de los cambios, pero si no es posible, cualquier miembro del equipo puede hacerlo.
-7. Si es que la PR es aprobada, un mantenedor del proyecto hará merge del código a `development`. Una vez hecho el merge puedes eliminar tu branch.
-
-## Tutorial
-
-### Como hacer Pull Requests
-
-Primero debe crear un `fork` del repositorio para poder realizar cambios en él.Se pueden encontrar mas detalles en [GitHub Documentation](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
-
-Luego agrega tu fork como un proyecto local:
-
-```sh
-# Using HTTPS
-git clone https://github.com/YOUR-USERNAME/REPOSITORY-NAME
-
-# Using SSH
-git clone git@github.com:YOUR-USERNAME/REPOSITORY-NAME
-```
-
-> [Which remote URL should be used ?](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories)
-
-Luego, ve a tu carpeta local
-
-```sh
-cd github-issue-template
-```
-
-Agregue git remote controls:
-
-```sh
-# Using HTTPS
-git remote add fork https://github.com/YOUR-USERNAME/REPOSITORY-NAME
-git remote add upstream https://github.com/YOUR-USERNAME/REPOSITORY-NAME
-
-
-# Using SSH
-git remote add fork git@github.com:YOUR-USERNAME/REPOSITORY-NAME
-git remote add upstream git@github.com/YOUR-USERNAME/REPOSITORY-NAME
-```
-
-Ahora puede verificar que tienes dos remote controls:
-
-```sh
-git remote -v
-```
-
-### Realizar actualizaciones remotas
-
-Para mantenerse al día con el repositorio central:
-
-```sh
-git pull upstream main # or master
-```
-
-### Elija una branch de base
-
-Antes de comenzar el desarrollo, debe saber en qué branch basar sus modificaciones/adiciones. En caso de duda, use main o master.
-
-```sh
-# Cambiar a la branch deseada
-git switch main # master
-
-# Hacer pull de los cambios
-git pull
-
-# Crear una nueva branch para trabajar
-git switch --create patch/1234-name-issue
-```
-
-Comprometa tus cambios, luego realiza push a la rama a tu fork con `git push -u fork` y abra una pull request con la plantilla proporcionada.
-
-## Más información
-
-Puedes encontrar mas detalles sobre este proceso [aquí](https://docs.github.com/es/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests).
+1. (Recomendado) Discutir tu propuesta previamente creando una issue.
+2. [Crea y clona un _fork_ del repositorio](https://docs.github.com/es/get-started/quickstart/fork-a-repo) para hacer tus cambios, o si tienes los permisos, crear una nueva branch bajo el mismo repositorio. Si ya tienes fork, [sincroniza el repositorio con upstream](https://docs.github.com/es/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
+3. Crear una branch a partir de la branch principal con un nombre significativo.
+4. Añade commits con tus cambios. Usa el estilo de [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) para mantener un historial de cambios ordenado y legible
+5. [Crea un Pull Request](https://docs.github.com/es/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). Entrega una descripción de los cambios, notas importantes, y añade que issues se están resolviendo.
+6. Asegurate que los _checks_ de GitHub pasen. Si no pasan, revisa los errores y corrige los problemas. Además, si es que se te solicitan cambios, corrígelos.
+7. Si es que la PR es aprobada, un mantenedor del proyecto hará merge y será parte del proyecto 🚀

--- a/contributing.md
+++ b/contributing.md
@@ -7,7 +7,7 @@ De partida, muchas gracias por contribuir al proyecto 🚀
 1. (Recomendado) Discutir tu propuesta previamente creando una issue.
 2. [Crea y clona un _fork_ del repositorio](https://docs.github.com/es/get-started/quickstart/fork-a-repo) para hacer tus cambios, o si tienes los permisos, crear una nueva branch bajo el mismo repositorio. Si ya tienes fork, [sincroniza el repositorio con upstream](https://docs.github.com/es/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 3. Crear una branch a partir de la branch principal con un nombre significativo.
-4. Añade commits con tus cambios. Usa el estilo de [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) para mantener un historial de cambios ordenado y legible
+4. Añade commits con tus cambios. Usa el estilo de [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) para mantener un historial de cambios ordenado y legible.
 5. [Crea un Pull Request](https://docs.github.com/es/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). Entrega una descripción de los cambios, notas importantes, y añade que issues se están resolviendo.
 6. Asegurate que los _checks_ de GitHub pasen. Si no pasan, revisa los errores y corrige los problemas. Además, si es que se te solicitan cambios, corrígelos.
 7. Si es que la PR es aprobada, un mantenedor del proyecto hará merge y será parte del proyecto 🚀


### PR DESCRIPTION
Esta PR busca agilizar el proceso de setup para llegar a realizar una contribución al repositorio.

Los cambios son:

- Separación de los pasos sugeridos, para que quede menos denso.
- Explicación de como usar GitHub Codespaces.
- Se mueve el punteo sobre mocks que había en el tercer punto a una sección aparte.
- Se indica que hay que esperar a que el backend termina de configurarse antes de poder ingresar a la aplicación.
- Se entrega un usuario de ejemplo en el mismo readme.
- Arreglar el archivo `contributing.md`. Se elimina el tutorial en favor de dejar linkeada las guías que tiene GitHub.

Creo que hay algunas cosas que probablemente se puedan mejorar más (especialmente contributing), pero es una mejora que toca un par de problemas que tuve en el setup.

Esta PR busca cerrar:
- https://github.com/open-source-uc/planner/issues/114