### PR TITLE
Ordenar cursos por color al generar

### DIFF
--- a/backend/app/plan/generation.py
+++ b/backend/app/plan/generation.py
@@ -110,11 +110,11 @@ def _get_credits(courseinfo: CourseInfo, courseid: PseudoCourse) -> int:
 
 
 SUPERBLOCK_COLOR_ORDER_TABLE: dict[str, int] = {
-    "plancomun": 0,
-    "major": 1,
-    "minor": 2,
-    "titulo": 3,
-    "formaciongeneral": 4,
+    "PlanComun": 0,
+    "Major": 1,
+    "Minor": 2,
+    "Titulo": 3,
+    "FormacionGeneral": 4,
 }
 
 

--- a/backend/app/plan/generation.py
+++ b/backend/app/plan/generation.py
@@ -18,7 +18,6 @@ from .validation.curriculum.solve import (
 )
 from .validation.curriculum.tree import (
     LATEST_CYEAR,
-    Curriculum,
     CurriculumSpec,
     Cyear,
 )
@@ -27,7 +26,7 @@ from .validation.validate import quick_validate_dependencies
 RECOMMENDED_CREDITS_PER_SEMESTER = 50
 
 
-def _extract_active_fillers(
+def _compute_courses_to_pass(
     g: SolvedCurriculum,
 ) -> list[PseudoCourse]:
     """
@@ -62,23 +61,6 @@ def _extract_active_fillers(
             pseudocourse_with_credits(course.fill_with.course, info.active_flow),
         )
     return flattened
-
-
-def _compute_courses_to_pass(
-    courseinfo: CourseInfo,
-    curriculum: Curriculum,
-    passed_classes: list[list[PseudoCourse]],
-) -> list[PseudoCourse]:
-    """
-    Given a curriculum with recommendations, and a plan that is considered as "passed",
-    add classes after the last semester to match the recommended plan.
-    """
-
-    # Determine which curriculum blocks have not been passed yet
-    g = solve_curriculum(courseinfo, curriculum, passed_classes)
-
-    # Extract recommended courses from solved plan
-    return _extract_active_fillers(g)
 
 
 def _find_corequirements(out: list[str], expr: Expr):
@@ -125,6 +107,33 @@ def _get_credits(courseinfo: CourseInfo, courseid: PseudoCourse) -> int:
     if creds is None:
         creds = 0
     return creds
+
+
+SUPERBLOCK_COLOR_ORDER_TABLE: dict[str, int] = {
+    "plancomun": 0,
+    "major": 1,
+    "minor": 2,
+    "titulo": 3,
+    "formaciongeneral": 4,
+}
+
+
+def _get_course_color_order(
+    g: SolvedCurriculum,
+    rep_counter: defaultdict[str, int],
+    course: PseudoCourse,
+) -> int:
+    """
+    Get the course "priority", which depends on the "color" of the course.
+    The color of the course is basically what superblock it counts towards.
+    Courses with lower priority number go before courses with a higher priority number.
+    """
+    rep_idx = rep_counter[course.code]
+    rep_counter[course.code] += 1
+    superblock = ""
+    if course.code in g.superblocks and rep_idx < len(g.superblocks[course.code]):
+        superblock = g.superblocks[course.code][rep_idx]
+    return SUPERBLOCK_COLOR_ORDER_TABLE.get(superblock, 1000)
 
 
 def _determine_coreq_components(
@@ -279,8 +288,12 @@ async def generate_recommended_plan(passed: ValidatablePlan):
     courseinfo = await course_info()
     curriculum = await get_curriculum(passed.curriculum)
 
+    # Solve the curriculum to determine which courses have not been passed yet (and need
+    # to be passed)
+    g = solve_curriculum(courseinfo, curriculum, passed.classes)
+
     # Flat list of all curriculum courses left to pass
-    courses_to_pass = _compute_courses_to_pass(courseinfo, curriculum, passed.classes)
+    courses_to_pass = _compute_courses_to_pass(g)
 
     plan = passed.copy(deep=True)
     plan.classes.append([])
@@ -332,8 +345,23 @@ async def generate_recommended_plan(passed: ValidatablePlan):
     while plan.classes and not plan.classes[-1]:
         plan.classes.pop()
 
+    # If any courses simply could not be added, add them now
+    # TODO: Do something about courses with missing requirements
     if courses_to_pass:
         print(f"WARNING: could not add courses {courses_to_pass}")
         plan.classes.append(courses_to_pass)
+
+    # Order courses by their color (ie. superblock assignment)
+    repetition_counter: defaultdict[str, int] = defaultdict(lambda: 0)
+    plan.classes = [
+        [
+            c
+            for _order, c in sorted(
+                ((_get_course_color_order(g, repetition_counter, c), c) for c in sem),
+                key=lambda pair: pair[0],
+            )
+        ]
+        for sem in plan.classes
+    ]
 
     return plan

--- a/backend/app/plan/validation/curriculum/solve.py
+++ b/backend/app/plan/validation/curriculum/solve.py
@@ -42,7 +42,7 @@ from typing import Any
 
 from ...course import ConcreteId, EquivalenceId, PseudoCourse
 from ...courseinfo import CourseInfo
-from .tree import Block, Curriculum, FillerCourse, Leaf
+from .tree import SUPERBLOCK_PREFIX, Block, Curriculum, FillerCourse, Leaf
 
 # Cost of using a concrete course.
 TAKEN_CONCRETE_COST = 10**1
@@ -246,6 +246,8 @@ class SolvedCurriculum:
     layers: defaultdict[str, LayerCourses]
     # Taken courses.
     taken: TakenCourses
+    # Indicates the main superblock that each course counts towards.
+    superblocks: dict[str, list[str]]
 
     def __init__(self) -> None:
         self.nodes = [Node(debug_name="source"), Node(debug_name="sink")]
@@ -254,6 +256,7 @@ class SolvedCurriculum:
         self.sink = 1
         self.layers = defaultdict(LayerCourses)
         self.taken = TakenCourses(flat=[], mapped=defaultdict(list))
+        self.superblocks = {}
 
     def add(self, node: Node) -> int:
         """
@@ -713,6 +716,59 @@ def _max_flow_min_cost(g: SolvedCurriculum):
             cur = edge.src
 
 
+def _tag_active_edges(g: SolvedCurriculum):
+    for layer in g.layers.values():
+        for courses in layer.courses.values():
+            for course in courses.values():
+                # Find the active edge
+                for edge in course.edges:
+                    if g.edges[edge.edge_id].flow > 0:
+                        course.active_edge = edge
+                        course.active_flow = g.edges[edge.edge_id].flow
+                        break
+
+
+def _tag_superblocks(g: SolvedCurriculum):
+    # Collect all courses
+    all_courses: dict[str, int] = {}
+    for layer in g.layers.values():
+        for code, reps in layer.courses.items():
+            for rep_idx in reps:
+                all_courses[code] = max(all_courses.get(code, 0), rep_idx + 1)
+
+    # Determine superblocks from active edges
+    layer_ids = sorted(g.layers)
+    g.superblocks = {}
+    for code, rep_count in all_courses.items():
+        g.superblocks[code] = []
+
+        for rep_idx in range(rep_count):
+            # Find the active superblock
+            superblock = ""
+
+            # Attempt to find a course superblock in some layer (prioritizing the
+            # default "" layer)
+            for layer_id in layer_ids:
+                layer = g.layers[layer_id]
+                if code not in layer.courses:
+                    continue
+                if rep_idx not in layer.courses[code]:
+                    continue
+                info = layer.courses[code][rep_idx]
+                if info.active_edge is None:
+                    continue
+                # Use the first superblock block in the path
+                for block in info.active_edge.block_path:
+                    if block.block_code.startswith(SUPERBLOCK_PREFIX):
+                        superblock = block.block_code[len(SUPERBLOCK_PREFIX) :]
+                        break
+                if superblock != "":
+                    break
+
+            # Tag it
+            g.superblocks[code].append(superblock)
+
+
 def solve_curriculum(
     courseinfo: CourseInfo,
     curriculum: Curriculum,
@@ -723,15 +779,9 @@ def solve_curriculum(
     # Solve the flow problem on the produced graph
     _max_flow_min_cost(g)
     # Determine active edges
-    for layer in g.layers.values():
-        for courses in layer.courses.values():
-            for course in courses.values():
-                # Find the active edge
-                for edge in course.edges:
-                    if g.edges[edge.edge_id].flow > 0:
-                        course.active_edge = edge
-                        course.active_flow = g.edges[edge.edge_id].flow
-                        break
+    _tag_active_edges(g)
+    # Determine course superblocks
+    _tag_superblocks(g)
     # Ensure that demand is satisfied exactly
     # Recommended courses should always fill in missing demand
     # It's a bug if they cannot fill in the demand

--- a/backend/app/plan/validation/curriculum/tree.py
+++ b/backend/app/plan/validation/curriculum/tree.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, Field
 
 from ...course import PseudoCourse
 
+SUPERBLOCK_PREFIX = "superblock:"
+
 
 class FillerCourse(BaseModel):
     """
@@ -32,6 +34,9 @@ class BaseBlock(BaseModel):
     # The name of this block.
     # Used for debug purposes.
     debug_name: str
+    # Computer-readable code for this block.
+    # Identifies the block.
+    block_code: str
     # The user-facing name of this block.
     # May not be present (eg. the root block has no name).
     name: str | None

--- a/backend/app/plan/validation/diagnostic.py
+++ b/backend/app/plan/validation/diagnostic.py
@@ -232,13 +232,7 @@ class ValidationResult(BaseModel):
 
     @staticmethod
     def empty(plan: ValidatablePlan) -> "ValidationResult":
-        blocks: dict[str, list[str]] = {}
-        for sem in plan.classes:
-            for c in sem:
-                if c.code not in blocks:
-                    blocks[c.code] = []
-                blocks[c.code].append("")
-        return ValidationResult(diagnostics=[], course_superblocks=blocks)
+        return ValidationResult(diagnostics=[], course_superblocks={})
 
     def add(self, diag: Diagnostic):
         self.diagnostics.append(diag)

--- a/backend/app/sync/siding/siding_rules.py
+++ b/backend/app/sync/siding/siding_rules.py
@@ -57,12 +57,12 @@ def _skip_extras(curriculum: Curriculum):
 # Tabla que mapea la primera palabra del nombre textual de un bloque academico a un
 # nombre mas machine-readable
 SUPERBLOCK_TABLE = {
-    "ciencias": "plancomun",
-    "base": "plancomun",
-    "formacion": "formaciongeneral",
-    "major": "major",
-    "minor": "minor",
-    "ingeniero": "titulo",
+    "ciencias": "PlanComun",
+    "base": "PlanComun",
+    "formacion": "FormacionGeneral",
+    "major": "Major",
+    "minor": "Minor",
+    "ingeniero": "Titulo",
 }
 
 

--- a/frontend/src/pages/planner/Planner.tsx
+++ b/frontend/src/pages/planner/Planner.tsx
@@ -140,8 +140,7 @@ const Planner = (): JSX.Element => {
       digest.courses = validatablePlan.classes.map((semester, i) => {
         return semester.map((course, j) => {
           const { code, instance } = planDigest.indexToId[i][j]
-          const rawSuperblock = validationResult?.course_superblocks?.[code]?.[instance] ?? null
-          const superblock = rawSuperblock === null ? '' : rawSuperblock.normalize('NFD').replace(/[\u0300-\u036f]/g, '').split(' ')[0]
+          const superblock = validationResult?.course_superblocks?.[code]?.[instance] ?? ''
           return {
             superblock,
             errorIndices: [],

--- a/frontend/src/pages/planner/planBoard/CourseCard.tsx
+++ b/frontend/src/pages/planner/planBoard/CourseCard.tsx
@@ -41,15 +41,15 @@ interface ConditionalWrapperProps {
 
 const BlockInitials = (courseBlock: string): string => {
   switch (courseBlock) {
-    case 'plancomun':
+    case 'PlanComun':
       return 'PC'
-    case 'formaciongeneral':
+    case 'FormacionGeneral':
       return 'FG'
-    case 'major':
+    case 'Major':
       return 'M'
-    case 'minor':
+    case 'Minor':
       return 'm'
-    case 'titulo':
+    case 'Titulo':
       return 'T'
   }
   return ''

--- a/frontend/src/pages/planner/planBoard/CourseCard.tsx
+++ b/frontend/src/pages/planner/planBoard/CourseCard.tsx
@@ -41,17 +41,15 @@ interface ConditionalWrapperProps {
 
 const BlockInitials = (courseBlock: string): string => {
   switch (courseBlock) {
-    case 'Ciencias':
+    case 'plancomun':
       return 'PC'
-    case 'Base':
-      return 'PC'
-    case 'Formacion':
+    case 'formaciongeneral':
       return 'FG'
-    case 'Major':
+    case 'major':
       return 'M'
-    case 'Minor':
+    case 'minor':
       return 'm'
-    case 'Ingeniero':
+    case 'titulo':
       return 'T'
   }
   return ''


### PR DESCRIPTION
# ¿Qué se implementa?

- Se mueve el mapeo de 'nombre interno bloque academico SIDING' -> 'nombre de superbloque' al backend. Ahora el frontend recibe códigos de superbloque: 'PlanComun', 'Major', 'Minor', 'Titulo', 'FormacionGeneral'.
- Se ordenan los ramos por color al generar. (closes PAN-154)

# Notas

No estaba seguro si esto debía ir en el frontend o backend, porque al final es un tema estético de los colores. También, el frontend ya tenía una tabla que mapeaba nombres como 'Ingeniero Civil en Computación' a 'T' de título.

Al final me decidí por moverlo al backend porque hacerlo en el frontend tiene algunos problemas: primero se genera el plan, después hay que validarlo para sacar los colores de cada ramo, y si después se reordena habría que validar de nuevo o suponer que reordenar no cambia la validación, que podría no siempre ser cierto.

No estaba seguro del orden que usar, pero después de pensarlo un rato _plan comun_, _major_, _minor_, _titulo_, _formacion general_ es el más natural creo: el orden estándar + formación general al final porque es como "extra".

**IMPORTANTE**: Es necesario resetear la base de datos (en verdad, solo es necesario vaciar la tabla `Curriculum` para que se regenere, pero resetear es mas facil).