### PR TITLE
Fix Pydantic errors and increase validation coverage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,8 @@
             "request": "launch",
             "module": "uvicorn",
             "args": [
-                "app.main:app"
+                "app.main:app",
+                "--reload",
             ],
             "justMyCode": true,
             "cwd": "${workspaceFolder}/backend"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,4 +67,5 @@
         "backend/typings/"
     ],
     "python.analysis.autoImportCompletions": true,
+    "debug.onTaskErrors": "debugAnyway",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,7 +32,7 @@
                     }],
                     "background": {
                         "activeOnStart": true,
-                        "beginsPattern": "Back-end started",
+                        "beginsPattern": "Waiting for back-end",
                         "endsPattern": "."
                     }
                 },

--- a/backend/app/plan/generation.py
+++ b/backend/app/plan/generation.py
@@ -35,9 +35,6 @@ from .validation.curriculum.tree import (
     LATEST_CYEAR,
     CurriculumSpec,
     Cyear,
-    MajorCode,
-    MinorCode,
-    TitleCode,
 )
 
 RECOMMENDED_CREDITS_PER_SEMESTER = 50
@@ -426,9 +423,9 @@ async def generate_empty_plan(user: UserKey | None = None) -> ValidatablePlan:
         classes = student.passed_courses
         curriculum = CurriculumSpec(
             cyear=cyear,
-            major=MajorCode(student.info.reported_major),
-            minor=MinorCode(student.info.reported_minor),
-            title=TitleCode(student.info.reported_title),
+            major=student.info.reported_major,
+            minor=student.info.reported_minor,
+            title=student.info.reported_title,
         )
     return ValidatablePlan(
         version="0.0.1",

--- a/backend/app/plan/validation/curriculum/tree.py
+++ b/backend/app/plan/validation/curriculum/tree.py
@@ -169,7 +169,10 @@ class CurriculumCode(str):
     A code for a major or a minor.
     """
 
-    pattern: re.Pattern[str] | None = None
+    _pattern: re.Pattern[str]
+
+    def __new__(cls: type[Self], value: str) -> Self:
+        return super().__new__(cls, value)
 
     @classmethod
     def __get_validators__(
@@ -179,11 +182,11 @@ class CurriculumCode(str):
 
     @classmethod
     def validate(cls: type[Self], value: str, field: ModelField) -> Self:
-        assert cls.pattern is not None
+        assert cls._pattern is not None
         if not isinstance(value, str):  # type: ignore
             raise TypeError("string required")
         value = value.strip().upper()
-        m = cls.pattern.fullmatch(value)
+        m = cls._pattern.fullmatch(value)
         if m is None:
             raise ValueError(f"Invalid {cls.__name__} code {value}")
         return cls(value)
@@ -194,37 +197,37 @@ class CurriculumCode(str):
 
 
 class MajorCode(CurriculumCode):
-    pattern = re.compile(r"^M[0-9]{3}$")
+    _pattern = re.compile(r"^M[0-9]{3}$")
 
     @classmethod
     def __modify_schema__(cls: type[Self], field_schema: dict[str, Any]) -> None:
         field_schema.update(
             description="A major code, eg. `M072` for hydraulic engineering.",
-            pattern=cls.pattern,
+            pattern=cls._pattern.pattern,
             examples=["M072", "M262", "M232"],
         )
 
 
 class MinorCode(CurriculumCode):
-    pattern = re.compile(r"^N[0-9]{3}$")
+    _pattern = re.compile(r"^N[0-9]{3}$")
 
     @classmethod
     def __modify_schema__(cls: type[Self], field_schema: dict[str, Any]) -> None:
         field_schema.update(
             description="A minor code, eg. `N204` for numerical analysis.",
-            pattern=cls.pattern,
+            pattern=cls._pattern.pattern,
             examples=["N204", "N199", "N776"],
         )
 
 
 class TitleCode(CurriculumCode):
-    pattern = re.compile(r"^4[0-9]{4}(?:-[0-9])?$")
+    _pattern = re.compile(r"^4[0-9]{4}(?:-[0-9])?$")
 
     @classmethod
     def __modify_schema__(cls: type[Self], field_schema: dict[str, Any]) -> None:
         field_schema.update(
             description="A title code, eg. `40007` for a computer engineering.",
-            pattern=cls.pattern,
+            pattern=cls._pattern.pattern,
             examples=["40008", "40023", "40096"],
         )
 

--- a/backend/app/sync/siding/client.py
+++ b/backend/app/sync/siding/client.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import json
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 import httpx
 import zeep
-from pydantic import BaseModel, parse_obj_as
+from pydantic import BaseModel, ConstrainedStr, Field, parse_obj_as
 from zeep import AsyncClient
 from zeep.transports import AsyncTransport
+
+from app.plan.validation.curriculum.tree import MajorCode, MinorCode, TitleCode
 
 from ...settings import settings
 
@@ -21,7 +25,7 @@ class StringArray(BaseModel):
 
 
 class Major(BaseModel):
-    CodMajor: str
+    CodMajor: MajorCode
     Nombre: str
     VersionMajor: str
     # For some reason after a SIDING update majors stopped having associated
@@ -30,8 +34,11 @@ class Major(BaseModel):
     Curriculum: StringArray | None
 
 
+Major.update_forward_refs()
+
+
 class Minor(BaseModel):
-    CodMinor: str
+    CodMinor: MinorCode
     Nombre: str
     TipoMinor: Literal["Amplitud"] | Literal["Profundidad"]
     VersionMinor: str | None
@@ -42,7 +49,7 @@ class Minor(BaseModel):
 
 
 class Titulo(BaseModel):
-    CodTitulo: str
+    CodTitulo: TitleCode
     Nombre: str
     TipoTitulo: Literal["CIVIL"] | Literal["INDUSTRIAL"]
     VersionTitulo: str | None
@@ -54,17 +61,16 @@ class Titulo(BaseModel):
 
 class PlanEstudios(BaseModel):
     CodCurriculum: str
-    CodMajor: str
-    CodMinor: str
-    CodTitulo: str | None
+    CodMajor: MajorCode | Literal["M"]
+    CodMinor: MinorCode
+    CodTitulo: TitleCode | Literal[""]
 
 
 class Curso(BaseModel):
     Sigla: str
     Nombre: str | None
-    # Strings like `I`, `II`, `I y II`, o `None`
-    Semestralidad: str | None
-    Creditos: int | None
+    Semestralidad: Literal["I", "II", "I y II"] | None
+    Creditos: Annotated[int, Field(ge=0, le=65)] | None
 
 
 class ListaCursos(BaseModel):
@@ -111,22 +117,22 @@ class InfoEstudiante(BaseModel):
     # Full name, all uppercase and with Unicode accents.
     Nombre: str
     # Either 'M' or 'F'.
-    Sexo: str
+    Sexo: Literal["M", "F"]
     # The cyear string associated with the student (e.g. "C2020", "C2013", etc...).
     # Usually coupled with `PeriodoAdmision`
     Curriculo: str
     # Major code of the self-reported intended major.
-    MajorInscrito: str | None
+    MajorInscrito: MajorCode | None
     # Minor code of the self-reported intended minor.
-    MinorInscrito: str | None
+    MinorInscrito: MinorCode | None
     # Title code of the self-reported intended title.
-    TituloInscrito: str | None
+    TituloInscrito: TitleCode | None
     # Not really sure what this is.
     # Seems to be `None`.
     Codigo: str | None
     # Career
     # Should be 'INGENIERÍA CIVIL' (mind the Unicode accent)
-    Carrera: str
+    Carrera: Literal["INGENIERÍA CIVIL"]
     # Semester in which the student joined the university.
     # For example, '2012-2' for the second semester of 2012.
     PeriodoAdmision: str
@@ -137,6 +143,10 @@ class InfoEstudiante(BaseModel):
     # Student status
     # Regular students have 'REGULAR' status.
     # Not useful for us, and it may even be sensitive data, so it's best to ignore it
+
+
+class AcademicPeriod(ConstrainedStr):
+    regex = r"\d{4}-[1-3]"
 
 
 class CursoHecho(BaseModel):
@@ -150,7 +160,7 @@ class CursoHecho(BaseModel):
     Estado: str
     # When was the course taken.
     # E.g. "2020-2" for the second semester of the year 2020
-    Periodo: str
+    Periodo: AcademicPeriod
     # Not sure, but probably whether the course is catedra or lab.
     # Seems to be `None`
     TipoCurso: str | None
@@ -173,8 +183,7 @@ class SoapClient:
         # Load mockup data
         if settings.siding_mock_path != "":
             try:
-                with settings.siding_mock_path.open() as file:
-                    self.mock_db = json.load(file)
+                self.mock_db = json.loads(settings.siding_mock_path.read_text())
                 cnt = sum(len(r) for r in self.mock_db.values())
                 print(
                     f"loaded {cnt} SIDING mock responses from"
@@ -310,12 +319,7 @@ async def get_courses_for_spec(study_spec: PlanEstudios) -> list[Curso]:
         list[Curso],
         await client.call_endpoint(
             "getConcentracionCursos",
-            {
-                "CodCurriculum": study_spec.CodCurriculum,
-                "CodMajor": study_spec.CodMajor,
-                "CodMinor": study_spec.CodMinor,
-                "CodTitulo": study_spec.CodTitulo,
-            },
+            study_spec.dict(),
         ),
     )
 
@@ -324,16 +328,12 @@ async def get_curriculum_for_spec(study_spec: PlanEstudios) -> list[BloqueMalla]
     """
     Get a list of curriculum blocks for the given spec.
     """
+    print(study_spec.dict())
     return parse_obj_as(
         list[BloqueMalla],
         await client.call_endpoint(
             "getMallaSugerida",
-            {
-                "CodCurriculum": study_spec.CodCurriculum,
-                "CodMajor": study_spec.CodMajor,
-                "CodMinor": study_spec.CodMinor,
-                "CodTitulo": study_spec.CodTitulo,
-            },
+            study_spec.dict(),
         ),
     )
 
@@ -355,11 +355,8 @@ async def get_equivalencies(course_code: str, study_spec: PlanEstudios) -> list[
             "getCursoEquivalente",
             {
                 "Sigla": course_code,
-                "CodCurriculum": study_spec.CodCurriculum,
-                "CodMajor": study_spec.CodMajor,
-                "CodMinor": study_spec.CodMinor,
-                "CodTitulo": study_spec.CodTitulo,
-            },
+            }
+            | study_spec.dict(),
         ),
     )
 
@@ -377,11 +374,8 @@ async def get_requirements(course_code: str, study_spec: PlanEstudios) -> list[C
             "getRequisito",
             {
                 "Sigla": course_code,
-                "CodCurriculum": study_spec.CodCurriculum,
-                "CodMajor": study_spec.CodMajor,
-                "CodMinor": study_spec.CodMinor,
-                "CodTitulo": study_spec.CodTitulo,
-            },
+            }
+            | study_spec.dict(),
         ),
     )
 
@@ -401,11 +395,8 @@ async def get_restrictions(
             "getRestriccion",
             {
                 "Sigla": course_code,
-                "CodCurriculum": study_spec.CodCurriculum,
-                "CodMajor": study_spec.CodMajor,
-                "CodMinor": study_spec.CodMinor,
-                "CodTitulo": study_spec.CodTitulo,
-            },
+            }
+            | study_spec.dict(),
         ),
     )
 

--- a/backend/app/sync/siding/client.py
+++ b/backend/app/sync/siding/client.py
@@ -13,6 +13,8 @@ from zeep.transports import AsyncTransport
 
 from app.plan.validation.curriculum.tree import MajorCode, MinorCode, TitleCode
 
+from ...settings import settings
+
 
 class StringArrayInner(BaseModel):
     string: list[str]
@@ -180,8 +182,6 @@ class SoapClient:
         self.record_path = None
 
     def on_startup(self):
-        from ...settings import settings
-
         # Load mockup data
         if settings.siding_mock_path != "":
             try:

--- a/backend/app/sync/siding/client.py
+++ b/backend/app/sync/siding/client.py
@@ -62,7 +62,7 @@ class Titulo(BaseModel):
 class PlanEstudios(BaseModel):
     CodCurriculum: str
     CodMajor: MajorCode | Literal["M"]
-    CodMinor: MinorCode
+    CodMinor: MinorCode | Literal["N"]
     CodTitulo: TitleCode | Literal[""]
 
 
@@ -70,7 +70,7 @@ class Curso(BaseModel):
     Sigla: str
     Nombre: str | None
     Semestralidad: Literal["I", "II", "I y II"] | None
-    Creditos: Annotated[int, Field(ge=0, le=65)] | None
+    Creditos: Annotated[int, Field(ge=0)] | None
 
 
 class ListaCursos(BaseModel):
@@ -113,11 +113,16 @@ class BloqueMalla(BaseModel):
     Restricciones: ListaRestricciones | None
 
 
+class AcademicPeriod(ConstrainedStr):
+    regex = r"\d{4}-[1-3]"
+
+
 class InfoEstudiante(BaseModel):
     # Full name, all uppercase and with Unicode accents.
     Nombre: str
-    # Either 'M' or 'F'.
-    Sexo: Literal["M", "F"]
+    # Seems to be either 'M' or 'F'.
+    # Not used.
+    Sexo: str
     # The cyear string associated with the student (e.g. "C2020", "C2013", etc...).
     # Usually coupled with `PeriodoAdmision`
     Curriculo: str
@@ -131,11 +136,12 @@ class InfoEstudiante(BaseModel):
     # Seems to be `None`.
     Codigo: str | None
     # Career
-    # Should be 'INGENIERÍA CIVIL' (mind the Unicode accent)
-    Carrera: Literal["INGENIERÍA CIVIL"]
+    # Seems to be 'INGENIERÍA CIVIL' (mind the Unicode accent)
+    # Not used
+    Carrera: str
     # Semester in which the student joined the university.
     # For example, '2012-2' for the second semester of 2012.
-    PeriodoAdmision: str
+    PeriodoAdmision: AcademicPeriod
 
     # Average student grades
     # Since this is somewhat sensitive data and we don't use it, it's best to ignore it
@@ -143,10 +149,6 @@ class InfoEstudiante(BaseModel):
     # Student status
     # Regular students have 'REGULAR' status.
     # Not useful for us, and it may even be sensitive data, so it's best to ignore it
-
-
-class AcademicPeriod(ConstrainedStr):
-    regex = r"\d{4}-[1-3]"
 
 
 class CursoHecho(BaseModel):

--- a/backend/app/sync/siding/client.py
+++ b/backend/app/sync/siding/client.py
@@ -13,8 +13,6 @@ from zeep.transports import AsyncTransport
 
 from app.plan.validation.curriculum.tree import MajorCode, MinorCode, TitleCode
 
-from ...settings import settings
-
 
 class StringArrayInner(BaseModel):
     string: list[str]
@@ -182,6 +180,8 @@ class SoapClient:
         self.record_path = None
 
     def on_startup(self):
+        from ...settings import settings
+
         # Load mockup data
         if settings.siding_mock_path != "":
             try:

--- a/backend/app/sync/siding/translate.py
+++ b/backend/app/sync/siding/translate.py
@@ -77,8 +77,8 @@ async def _fetch_raw_blocks(
 ) -> list[BloqueMalla]:
     # Use a dummy major and minor if they are not specified
     # Later, remove this information
-    major = "M245" if spec.major is None else spec.major
-    minor = "N344" if spec.minor is None else spec.minor
+    major = MajorCode("M245") if spec.major is None else spec.major
+    minor = MinorCode("N344") if spec.minor is None else spec.minor
 
     # Fetch raw curriculum blocks for the given cyear-major-minor-title combination
     raw_blocks = await client.get_curriculum_for_spec(
@@ -86,7 +86,7 @@ async def _fetch_raw_blocks(
             CodCurriculum=str(spec.cyear),
             CodMajor=major,
             CodMinor=minor,
-            CodTitulo=spec.title or None,
+            CodTitulo=spec.title or "",
         ),
     )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -98,3 +98,9 @@ exclude = [
     "typings",
 ]
 reportMissingTypeStubs = false
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # Ignore zeep DeprecationWarnings
+    "ignore::DeprecationWarning:zeep.*",
+]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -73,6 +73,7 @@ ignore = [
     "ANN201",
     "ANN202", # "Missing return type annotation" (sometimes return types are too complex)
     "S101",   # "Use of `assert` detected" (debug assertions are useful)
+    "TCH001" # Pydantic relies heavily on runtime type reflection
 ]
 
 extend-exclude = ["typings/"]

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -1,0 +1,35 @@
+import pytest
+from app.sync.siding.client import AcademicPeriod
+from pydantic import BaseModel, ValidationError
+
+
+class AcademicPeriodTest(BaseModel):
+    academic_period: AcademicPeriod
+
+
+def test_academic_period():
+    AcademicPeriodTest(academic_period=AcademicPeriod("2021-1"))
+    AcademicPeriodTest(academic_period=AcademicPeriod("2023-2"))
+    AcademicPeriodTest(academic_period=AcademicPeriod("2025-3"))
+
+    with pytest.raises(ValidationError):
+        AcademicPeriodTest(academic_period=AcademicPeriod("2021-0"))
+
+    with pytest.raises(ValidationError):
+        AcademicPeriodTest(academic_period=AcademicPeriod("2021-4"))
+
+    with pytest.raises(ValidationError):
+        AcademicPeriodTest(academic_period=AcademicPeriod("2021-5"))
+
+    with pytest.raises(ValidationError):
+        AcademicPeriodTest(academic_period=AcademicPeriod("KDSFDF"))
+
+    with pytest.raises(ValidationError):
+        AcademicPeriodTest(academic_period=AcademicPeriod(None))
+
+    # Test deserialization from a dict with str
+    d = {
+        "academic_period": "2021-1",
+    }
+    apt = AcademicPeriodTest.parse_obj(d)
+    assert str(apt.academic_period) == "2021-1"

--- a/backend/tests/test_tree.py
+++ b/backend/tests/test_tree.py
@@ -55,3 +55,24 @@ def test_codes():
     assert str(CurriculumCodeTest(major_code=MajorCode("M123")).major_code) == "M123"
     assert str(CurriculumCodeTest(minor_code=MinorCode("N123")).minor_code) == "N123"
     assert str(CurriculumCodeTest(title_code=TitleCode("40001")).title_code) == "40001"
+
+    # Test deserialization from string
+    d = {
+        "major_code": "M123",
+        "minor_code": "N123",
+        "title_code": "40001",
+    }
+    parsed_curriculum = CurriculumCodeTest.parse_obj(d)
+    assert parsed_curriculum.major_code == MajorCode("M123")
+    assert parsed_curriculum.minor_code == MinorCode("N123")
+    assert parsed_curriculum.title_code == TitleCode("40001")
+    # Test serialization to string
+    parsed_curriculum_dict = parsed_curriculum.dict()
+    assert parsed_curriculum_dict["major_code"] == "M123"
+    assert parsed_curriculum_dict["minor_code"] == "N123"
+    assert parsed_curriculum_dict["title_code"] == "40001"
+    # Check wrong deserialization
+    with pytest.raises(ValidationError):
+        CurriculumCodeTest.parse_obj({"major_code": "M1234"})
+        CurriculumCodeTest.parse_obj({"minor_code": "N1234"})
+        CurriculumCodeTest.parse_obj({"title_code": "400011"})

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,5 @@
+PLANNER_URL="http://localhost:3000"
+
+VITE_BASE_API_URL="/api"
+
+BACKEND_API_URL="http://localhost:8000"


### PR DESCRIPTION
Esto arregla bugs introducidos por #193 y valida más campos de interacción con el cliente. 

También restaura el archivo `.env.development` en el frontend (que parezco haber borrado por accidente hace un tiempo) y arregla un error de VSCode al lanzar tareas (errores en preLaunchTasks).

Todavía no logro que funcione la generación de mallas, pero no puedo trazar el error a cambios míos.