### PR TITLE
Full ansible deployment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,8 @@
 				"dbaeumer.vscode-eslint",
 				"ms-python.python",
 				"charliermarsh.ruff",
-				"kokakiwi.vscode-just"
+				"kokakiwi.vscode-just",
+				"redhat.ansible"
 			],
 			"settings": {
 				"terminal.integrated.env.linux": {

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
         "prisma.prisma",
         "bradlc.vscode-tailwindcss",
         "austenc.tailwind-docs",
-        "dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "redhat.ansible"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,4 +67,6 @@
         "backend/typings/"
     ],
     "python.analysis.autoImportCompletions": true,
+    // Ansible
+    "ansible.python.interpreterPath": "/workspaces/planner/backend/.venv/bin/python",
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="#descripción">Descripción</a> •
   <a href="#instalación-y-desarrollo">Instalación</a> •
   <a href="#mocks">Mocks</a> •
-  <a href="#staging-y-producción">Staging y Producción</a> •
+  <a href="#deployment">Deployment</a> •
   <a href="#equipo">Equipo</a> •
   <a href="contributors.md">Contribuidores</a> •
   <a href="#licencia">Licencia</a>

--- a/README.md
+++ b/README.md
@@ -88,9 +88,33 @@ El proyecto se integra con dos servicios externos: SIDING (para acceder a mallas
 - Para SIDING se provee un mock que se activa automáticamente en ausencia de credenciales. El mock es limitado, y solo permite probar algunas combinaciones de malla.
 - Para CAS, se provee el servicio `cas-server-mock` que corre automáticamente junto a la app. Las cuentas de usuario disponibles son configurables en el archivo `cas-mock/data/cas-mock-users.json`.
 
-## Staging y Producción
+## Deployment
 
-### Staging Server
+### Deployment automático
+Para deployments a producción, se provee un playbook de [Ansible](https://docs.ansible.com/ansible/latest/index.html)
+que permite levantar la app completa de principio a fin, pensado para su uso en un entorno de producción, en particular
+en un servidor corriendo [Rocky Linux 9](https://rockylinux.org/).
+
+Teniendo acceso SSH a un servidor, solo se necesita correr (desde un entorno de desarrollo ya configurado):
+
+```shell
+$ ansible-playbook infra/playbook.yml -i <IP>, -u <USUARIO>
+```
+
+Asumiendo que ya se tenga una llave SSH al servidor. El playbook es completamente idempotente, por lo que
+también puede ser utilizado para corregir configuration drift en un servidor de producción.
+
+El playbook opcionalmente provee prompts para entregar credenciales de Tailscale, Netdata y SIDING. Por defecto 
+el playbook no levanta un mock de CAS, que es necesario para instalaciones sin acceso al SSO UC.
+
+También se provee un script más ligero en [just](./justfile), que principalmente está pensado para su uso en
+junto al sistema de [Continuous Deployment](./.github/workflows/deploy.yml) del repositorio. Sin embargo,
+dado un entorno ya configurado de Docker Compose, este puede ser utilizado para levantar un servidor independiente, 
+incluyendo uno que utilice un SSO mock.
+
+Abajo se entregan instrucciones manuales de deploy.
+
+### Deployment manual: Staging
 
 El ambiente de staging está diseñado para testear las nuevas versiones del planner en un ambiente real antes de pasar a producción.
 
@@ -110,7 +134,7 @@ Alternativamente, para correr la aplicación utilizando un servidor mock de **CA
 
 Finalmente, se puede detener la app con `docker compose down` desde la raíz del repositorio.
 
-### Producción
+### Deployment manual: Producción
 
 El ambiente de producción es manejado por la universidad de forma interna, por lo que aquí se detallan las **instrucciones para desplegar el planner** de forma manual:
 1. Se deben crear tres archivos `.env`, uno por cada servicio y dentro de su respectiva carpeta:
@@ -126,8 +150,6 @@ El ambiente de producción es manejado por la universidad de forma interna, por 
 Nota: los comandos podrían variar ligeramente dependiendo del sistema operativo y versión de *Docker Compose*. En particular, podría ser necesario utilizar `docker-compose` en vez de `docker compose` y `sudo docker compose` en vez de `docker compose`.
 
 ---
-
-Cabe mencionar que sería ideal a futuro implementar un **despliegue automático del planner** utilizando técnicas de *CI/CD*, pero de momento esta opción se pospone debido a las restricciones de seguridad y requerimientos de la universidad para hacer un despliegue interno.
 
 ## Equipo
 

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -8,26 +8,26 @@
 # --> ejemplo: "https://plan.ing.puc.cl"
 #
 # NOTA: Incluir `https://` en este URL, de otra manera el token se mandará por HTTP desencriptado.
-PLANNER_URL=""
+# PLANNER_URL=""
 
 # URL que apunta al servidor de autenticacion CAS.
 # --> ejemplo: "https://sso.uc.cl/cas"
-CAS_SERVER_URL=""
+# CAS_SERVER_URL=""
 
 # RUT del administrador.
 # Es único y tiene el poder de añadir y remover moderadores.
 # Si se deja vacío no existirá administrador.
 # --> ejemplo: "012345678-K"
-ADMIN_RUT=""
+# ADMIN_RUT=""
 
 # Secreto para generar y verificar tokens JWT.
 # ADVERTENCIA: Si este secreto se filtra cualquier persona podría forjar tokens de autorización
 # para cualquier usuario!
-JWT_SECRET="mal secreto, REEMPLAZAR ESTO por un buen secreto."
+# JWT_SECRET="mal secreto, REEMPLAZAR ESTO por un buen secreto."
 
 # Credenciales para utilizar el webservice de Siding.
-SIDING_USERNAME="cambiar_esta_variable"
-SIDING_PASSWORD="cambiar_esta_variable"
+# SIDING_USERNAME="cambiar_esta_variable"
+# SIDING_PASSWORD="cambiar_esta_variable"
 
 # No debería ser necesario modificar esta variable, a menos que se modifiquen las credenciales
 # de la base de datos. En tal caso considerar la siguiente estructura:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -69,11 +69,10 @@ RUN prisma generate
 COPY --from=builder /tmp/.env /code/.env
 COPY --from=builder /tmp/app /code/app
 
+HEALTHCHECK --start-period=5m CMD curl -f http://localhost:8000/health || exit 1
+
 # Setup entrypoint
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 # Expose the necessary port
 EXPOSE 8000
-
-# Setup healthcheck
-HEALTHCHECK CMD curl -f http://localhost:8000/health || exit 1

--- a/cas-mock/Dockerfile
+++ b/cas-mock/Dockerfile
@@ -8,6 +8,6 @@ RUN apk --no-cache add curl
 EXPOSE 3004
 COPY ./data/cas-mock-users.json.example /app/data/cas-mock-users.json
 
-CMD ["npx", "--yes", "cas-server-mock", "--port=3004", "--database=/app/data/cas-mock-users.json"]
-
 HEALTHCHECK CMD curl --fail http://localhost:3004/ || exit 1
+
+CMD ["npx", "--yes", "cas-server-mock", "--port=3004", "--database=/app/data/cas-mock-users.json"]

--- a/database/.env.production
+++ b/database/.env.production
@@ -5,6 +5,6 @@
 ###############################################################################################
 
 # Credenciales y nombre de la base de datos
-POSTGRES_USER="cambiar_esta_variable"
-POSTGRES_PASSWORD="cambiar_esta_variable"
-POSTGRES_DB="cambiar_esta_variable"
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="postgres"
+POSTGRES_DB="postgres"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -38,8 +38,9 @@ COPY --from=app-builder /tmp/dist /srv
 # Copy Caddyfile for configuration
 COPY conf/Caddyfile /etc/caddy/Caddyfile
 
+# Healthcheck
+HEALTHCHECK CMD curl --fail http://localhost:80/ || exit 1
+
 # Run caddy using config file
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
 
-# Healthcheck
-HEALTHCHECK CMD curl --fail http://localhost:80/ || exit 1

--- a/infra/ansible.cfg
+++ b/infra/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+nocows = True
+
+[connection]
+pipelining = True

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -8,6 +8,20 @@
     - name: "machine_name"
       prompt: "Desired machine name (e.g. staging, optional)"
       private: false
+    - name: "planner_domain"
+      prompt: "Planner domain (e.g. planner.example.com, optional)"
+      private: false
+    - name: "cas_server_url"
+      prompt: "CAS URL (e.g. https://sso.uc.cl/cas, optional)"
+      private: false
+    - name: "admin_rut"
+      prompt: "Admin RUT (e.g. 12345678-9, optional)"
+      private: false
+    - name: "siding_username"
+      prompt: "SIDING username (e.g. admin, optional)"
+      private: false
+    - name: "siding_password"
+      prompt: "SIDING password (optional)"
     - name: "netdata_token"
       prompt: "Netdata Claim Token (optional)"
     - name: "netdata_room_id"
@@ -79,19 +93,38 @@
           - chrony
           # For the tailscale selinux policy
           - selinux-policy-devel
+          # For installing the just command runner
+          - snapd
 
           # Misc
           - fish
           - fortune-mod
           - neofetch
+          - cowsay
 
         state: present
 
-    - name: Install and configure micro editor # noqa: risky-shell-pipe command-instead-of-module
+    - name: Install and configure the micro editor # noqa: risky-shell-pipe command-instead-of-module
       ansible.builtin.shell:
         cmd: curl https://getmic.ro/r | bash
         creates: /usr/bin/micro
         chdir: /usr/bin
+
+    - name: Enable snapd
+      ansible.builtin.service:
+        name: snapd.socket
+        enabled: true
+        state: started
+
+    - name: Enable classic snap support
+      ansible.builtin.command:
+        cmd: ln -s /var/lib/snapd/snap /snap
+        creates: /snap
+
+    - name: Install the just command runner
+      ansible.builtin.command:
+        cmd: snap install just --classic --edge
+        creates: /snap/bin/just
 
     - name: Enable selinux
       ansible.posix.selinux:
@@ -287,20 +320,130 @@
     - name: Clone the planner repo # noqa: latest
       ansible.builtin.git:
         repo: "https://github.com/open-source-uc/planner.git"
-        dest: /opt/planner/
+        dest: /home/planner/planner/
+      become: true
+      become_user: planner
 
-    - name: Give planner user ownership of /opt/planner
-      ansible.builtin.file:
-        path: /opt/planner
+    - name: Create backend .env
+      ansible.builtin.copy:
+        src: /home/planner/planner/backend/.env.production
+        dest: /home/planner/planner/backend/.env
         owner: planner
         group: planner
-        recurse: true
+        mode: "0644"
+        force: false
+        remote_src: true
 
-    - name: Create symlink to planner repo
-      ansible.builtin.file:
-        src: /opt/planner
-        dest: /home/planner/planner
-        state: link
+    - name: Create frontend .env
+      ansible.builtin.copy:
+        src: /home/planner/planner/frontend/.env.production
+        dest: /home/planner/planner/frontend/.env
+        owner: planner
+        group: planner
+        mode: "0644"
+        force: false
+        remote_src: true
+
+    - name: Create database .env
+      ansible.builtin.copy:
+        src: /home/planner/planner/database/.env.production
+        dest: /home/planner/planner/database/.env
+        owner: planner
+        group: planner
+        mode: "0644"
+        force: false
+        remote_src: true
+
+    - name: Set planner_url
+      ansible.builtin.set_fact:
+        planner_url: "https://{{ planner_domain }}"
+      when: planner_domain | length > 0
+
+    - name: Configure back-end URL
+      ansible.builtin.lineinfile:
+        path: /home/planner/planner/backend/.env
+        regexp: '^PLANNER_URL'
+        line: 'PLANNER_URL={{ planner_url }}'
+        state: present
+        insertafter: '^# PLANNER_URL'
+        firstmatch: true
+      when: planner_domain | length > 0
+
+    - name: Configure CAS URL
+      ansible.builtin.lineinfile:
+        path: /home/planner/planner/backend/.env
+        regexp: '^CAS_SERVER_URL'
+        line: 'CAS_SERVER_URL={{ cas_server_url }}'
+        state: present
+        insertafter: '^# CAS_SERVER_URL'
+        firstmatch: true
+      when: cas_server_url | length > 0
+
+    - name: Configure admin RUT
+      ansible.builtin.lineinfile:
+        path: /home/planner/planner/backend/.env
+        regexp: '^ADMIN_RUT'
+        line: 'ADMIN_RUT={{ admin_rut }}'
+        state: present
+        insertafter: '^# ADMIN_RUT'
+        firstmatch: true
+      when: admin_rut | length > 0
+
+    - name: Configure SIDING username
+      ansible.builtin.lineinfile:
+        path: /home/planner/planner/backend/.env
+        regexp: '^SIDING_USERNAME'
+        line: 'SIDING_USERNAME={{ siding_username }}'
+        state: present
+        insertafter: '^# SIDING_USERNAME'
+        firstmatch: true
+      when: siding_username | length > 0
+
+    - name: Configure SIDING password
+      ansible.builtin.lineinfile:
+        path: /home/planner/planner/backend/.env
+        regexp: '^SIDING_PASSWORD'
+        line: 'SIDING_PASSWORD={{ siding_password }}'
+        state: present
+        insertafter: '^# SIDING_PASSWORD'
+        firstmatch: true
+      when: siding_password | length > 0
+
+    - name: Check if JWT secret is already configured
+      ansible.builtin.command:
+        cmd: grep -q '^JWT_SECRET' /home/planner/planner/backend/.env
+      register: jwt_secret_check
+      check_mode: false
+      changed_when: false
+      failed_when: false
+
+    - name: Configure JWT secret
+      ansible.builtin.lineinfile:
+        path: /home/planner/planner/backend/.env
+        regexp: '^JWT_SECRET'
+        line: "JWT_SECRET={{ lookup('community.general.random_string', length=64, base64=True) }}"
+        state: present
+        insertafter: '^# JWT_SECRET'
+        firstmatch: true
+      when: jwt_secret_check.rc != 0
+
+    - name: Configure front-end URL
+      ansible.builtin.lineinfile:
+        path: /home/planner/planner/frontend/.env
+        regexp: '^PLANNER_URL'
+        line: 'PLANNER_URL={{ planner_url }}'
+        state: present
+      when: planner_domain | length > 0
+
+    - name: Build and start containers
+      ansible.builtin.command:
+        cmd: docker compose up --build --remove-orphans --force-recreate --detach --wait-timeout 300 --wait planner
+        chdir: /home/planner/planner/
+      environment:
+        DOCKER_BUILDKIT: 1
+      changed_when: true
+      become: true
+      become_user: planner
 
   handlers:
     - name: Restart (and enable) chronyd

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -321,8 +321,20 @@
       ansible.builtin.git:
         repo: "https://github.com/open-source-uc/planner.git"
         dest: /home/planner/planner/
+        update: false
       become: true
       become_user: planner
+
+    - name: Update the planner repo # noqa: command-instead-of-module
+      ansible.builtin.shell:
+        cmd: |
+          git config advice.detachedHead false
+          git fetch --all
+          git checkout --force origin/main
+        chdir: /home/planner/planner/
+      become: true
+      become_user: planner
+      changed_when: true
 
     - name: Create backend .env
       ansible.builtin.copy:

--- a/infra/requirements.yml
+++ b/infra/requirements.yml
@@ -1,3 +1,6 @@
 ---
+collections:
+- name: ansible.posix
+- name: community.general
 roles:
 - name: artis3n.tailscale

--- a/justfile
+++ b/justfile
@@ -136,5 +136,5 @@ deploy environment=default_environment:
         TARGET_SERVICE="planner"
     fi
     echo -e "{{ info_prefix }} \e[1mStarting containers...\e[0m"
-    docker compose up --build --remove-orphans --force-recreate --detach --wait $TARGET_SERVICE
+    docker compose up --build --remove-orphans --force-recreate --detach --wait-timeout 300 --wait $TARGET_SERVICE
     echo -e "{{ info_prefix }} \e[1mDeployed to $DEPLOY_ENVIRONMENT successfully 🚀.\e[0m"


### PR DESCRIPTION
Este PR hace que el playbook de Ansible sea capaz de levantar la app completa de principio a fin automáticamente, incluyendo el levantamiento de los contenedores de Docker.

Esto significa que es posible correr:

```shell
$ ansible-playbook infra/playbook.yml -i <IP>, -u <USUARIO>
```

Y Ansible tomará todos los pasos necesarios para instalar paquetes, configurar el kernel, aplicar optimizaciones, conectarse la red de Tailscale, instalar el agente de Netdata, clonar y actualizar el repo de git e iniciar Docker Compose.

Una gracia es que es 100% idempotente, así que si algo no funciona, podemos correrlo de nuevo y debiese corregir cualquier “drift” en el servidor.