### PR TITLE
fix: add ansible in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # Install HTTPie via pip
 RUN python -m pip install --upgrade pip wheel
-RUN python -m pip install httpie
+RUN python -m pip install httpie ansible

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # Install HTTPie via pip
 RUN python -m pip install --upgrade pip wheel
-RUN python -m pip install httpie ansible
+RUN python -m pip install httpie

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ deps-back:
 
 deps-infra:
     @echo "{{ info_prefix }} \e[1mInstalling infrastructure dependencies...\e[0m"
-    cd infra && ansible-galaxy install -r requirements.yml
+    cd backend && ansible-galaxy install -r ../infra/requirements.yml
 
 deps: deps-front deps-back deps-infra
 


### PR DESCRIPTION
Al inicial el devcontainer tenía el siguiente error:

```
cd infra && ansible-galaxy install -r requirements.yml
deps-infra: 1: ansible-galaxy: not found
```

Esta PR añade `ansible-galaxy` en lo que se instala en el devcontainer.