### PR TITLE
Mejorar selector de version curriculum

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN chmod +x /usr/local/bin/just
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends postgresql-client watchman libonig-dev
+    && apt-get -y install --no-install-recommends postgresql-client watchman libonig-dev redis-tools
 
 # Install HTTPie via pip
 RUN python -m pip install --upgrade pip wheel

--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -12,9 +12,6 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
-
     # Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     # user: root
 
@@ -30,6 +27,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: postgres
+    network_mode: service:app
 
   redis:
     image: redis:7
@@ -39,6 +37,7 @@ services:
       - redis-data:/data
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
+    network_mode: service:app
 
 volumes:
   postgres-data:

--- a/backend/app/limiting.py
+++ b/backend/app/limiting.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable
 
 import limits
@@ -10,6 +11,15 @@ from .user.key import UserKey
 LIMIT_REACHED_ERROR = HTTPException(429, detail="Too many requests")
 
 storage = limits.storage.RedisStorage(settings.redis_uri)
+
+# Ping the Redis server to check if it is alive
+if not storage.check():
+    warnings.warn(
+        "Could not connect to Redis, falling back to in-memory storage.",
+        stacklevel=1,
+    )
+    storage = limits.storage.MemoryStorage()
+    assert storage.check()
 
 
 class Limiter:

--- a/frontend/src/pages/planner/CurriculumSelector.tsx
+++ b/frontend/src/pages/planner/CurriculumSelector.tsx
@@ -19,6 +19,7 @@ interface SelectorProps {
   canDeselect: boolean
   data: Record<string, { name: string }>
   value: string | null | undefined
+  showCode: boolean
   onChange: (value: string) => void
 }
 
@@ -27,6 +28,7 @@ const Selector = memo(function _Selector ({
   data,
   value,
   canDeselect,
+  showCode,
   onChange
 }: SelectorProps): JSX.Element {
   const selectedOption = value != null ? (data[value] ?? { name: `${name} Desconocido` }) : { name: 'Por Seleccionar' }
@@ -43,7 +45,7 @@ const Selector = memo(function _Selector ({
     <Listbox value={value} onChange={onChange}>
       <Listbox.Button className="selectorButton">
         <span className="inline truncate">
-          {selectedOption.name} {value != null && `(${value})`}
+          {selectedOption.name} {showCode && value != null && `(${value})`}
         </span>
         <svg
           className="inline"
@@ -93,7 +95,7 @@ const Selector = memo(function _Selector ({
                 <span
                   className={`block truncate ${selected ? 'font-medium text-black' : 'font-normal'}`}
                 >
-                  {data[key].name} ({key})
+                  {data[key].name} {showCode && `(${key})`}
                 </span>
                 {selected
                   ? (
@@ -133,6 +135,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
               canDeselect={false}
               data={curriculumData.majors}
               value={curriculumSpec.major}
+              showCode={true}
               onChange={(t) => selectMajor({ cyear: curriculumData.majors[t].cyear, code: t })}
             />
             : <svg
@@ -154,6 +157,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
               canDeselect={true}
               data={curriculumData.minors}
               value={curriculumSpec.minor}
+              showCode={true}
               onChange={(t) => selectMinor(t)}
             />
             : <svg
@@ -175,6 +179,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
               canDeselect={true}
               data={curriculumData.titles}
               value={curriculumSpec.title}
+              showCode={true}
               onChange={(t) => selectTitle(t)}
             />
           }
@@ -192,6 +197,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
                 C2022: { name: 'Admisión 2022 y posteriores' }
               }}
               value={curriculumSpec.cyear?.raw}
+              showCode={true}
               onChange={(c) => selectYear(c)}
             />
           }

--- a/frontend/src/pages/planner/CurriculumSelector.tsx
+++ b/frontend/src/pages/planner/CurriculumSelector.tsx
@@ -1,8 +1,9 @@
 import { Fragment, memo, useEffect } from 'react'
 import { Listbox, Transition } from '@headlessui/react'
-import { type Major, type Minor, type Title, type CurriculumSpec } from '../../client'
+import { type CurriculumSpec } from '../../client'
 import { type CurriculumData } from './utils/Types'
 import { toast } from 'react-toastify'
+import { useAuth } from '../../contexts/auth.context'
 
 interface CurriculumSelectorProps {
   planName: string
@@ -16,7 +17,7 @@ interface CurriculumSelectorProps {
 interface SelectorProps {
   name: string
   canDeselect: boolean
-  data: Record<string, Major | Minor | Title>
+  data: Record<string, { name: string }>
   value: string | null | undefined
   onChange: (value: string) => void
 }
@@ -28,7 +29,7 @@ const Selector = memo(function _Selector ({
   canDeselect,
   onChange
 }: SelectorProps): JSX.Element {
-  const selectedOption = value !== undefined && value !== null ? (data[value] ?? { name: 'Minor desconocido', code: value }) : { name: 'Por Seleccionar', code: null }
+  const selectedOption = value != null ? (data[value] ?? { name: `${name} Desconocido` }) : { name: 'Por Seleccionar' }
   if (value !== undefined && value !== null && data[value] === undefined) {
     useEffect(() => {
       toast.warn(`Tu ${name} todavía no está soportado oficialmente. Los cursos pueden estar incorrectos, revisa dos veces.`, {
@@ -39,10 +40,10 @@ const Selector = memo(function _Selector ({
     }, [value])
   }
   return (
-    <Listbox value={selectedOption.code} onChange={onChange}>
+    <Listbox value={value} onChange={onChange}>
       <Listbox.Button className="selectorButton">
         <span className="inline truncate">
-          {selectedOption.name} {selectedOption.code !== null && `(${selectedOption.code})`}
+          {selectedOption.name} {value != null && `(${value})`}
         </span>
         <svg
           className="inline"
@@ -121,13 +122,14 @@ const CurriculumSelector = memo(function CurriculumSelector ({
   selectTitle,
   selectYear
 }: CurriculumSelectorProps): JSX.Element {
+  const authState = useAuth()
   return (
       <ul className={'curriculumSelector'}>
         <li className={'selectorElement'}>
           <div className={'selectorName'}>Major:</div>
           {curriculumData != null
             ? <Selector
-              name="major"
+              name="Major"
               canDeselect={false}
               data={curriculumData.majors}
               value={curriculumSpec.major}
@@ -148,7 +150,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
           <div className={'selectorName'}>Minor:</div>
           {curriculumData != null
             ? <Selector
-              name="minor"
+              name="Minor"
               canDeselect={true}
               data={curriculumData.minors}
               value={curriculumSpec.minor}
@@ -169,7 +171,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
           <div className={'selectorName'}>Titulo:</div>
           {curriculumData != null &&
             <Selector
-              name="título"
+              name="Título"
               canDeselect={true}
               data={curriculumData.titles}
               value={curriculumSpec.title}
@@ -177,68 +179,24 @@ const CurriculumSelector = memo(function CurriculumSelector ({
             />
           }
         </li>
+        {
+        (authState?.user == null) &&
         <li className={'selectorElement'}>
-          <div className={'selectorName'}>Año Curriculum:</div>
-          {curriculumData != null &&
-            <Listbox value={curriculumSpec.cyear?.raw} onChange={(t) => selectYear(t)}>
-            <Listbox.Button className="selectorButton">
-              <span className="inline truncate">
-                {curriculumSpec.cyear?.raw}
-              </span>
-              <svg
-                className="inline"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                width="24"
-                height="24"
-              >
-                <path fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" d="M7 10l5 5 5-5"/>
-              </svg>
-            </Listbox.Button>
-            <Transition
-              as={Fragment}
-              leave="transition ease-in duration-100"
-              leaveFrom="opacity-100"
-              leaveTo="opacity-0"
-            >
-              <Listbox.Options className="curriculumOptions z-40 w-40">
-                  <Listbox.Option
-                    className={({ active }) =>
-                      `curriculumOption ${active ? 'bg-place-holder text-amber-800' : 'text-gray-900'}`
-                    }
-                    value={'C2022'}
-                  >
-                  {({ selected }) => (
-                    <>
-                      <span className={'block truncate font-medium  '}>
-                        C2022
-                      </span>
-                      {selected ? <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-800">*</span> : null}
-                    </>
-                  )}
-                </Listbox.Option>
-                <Listbox.Option
-                  className={({ active }) =>
-                    `curriculumOption ${active ? 'bg-place-holder text-amber-800' : 'text-gray-900'}`
-                  }
-                  value={'C2020'}
-                >
-                  {({ selected }) => (
-                    <>
-                      <span
-                        className={`block truncate ${selected ? 'font-medium text-black' : 'font-normal'}`}
-                      >
-                        C2020
-                      </span>
-                      {selected ? <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-800">*</span> : null}
-                    </>
-                  )}
-                </Listbox.Option>
-              </Listbox.Options>
-            </Transition>
-          </Listbox>
+          <div className={'selectorName'}>Versión Curriculum:</div>
+          {curriculumSpec != null &&
+            <Selector
+              name="Curriculum"
+              canDeselect={false}
+              data={{
+                C2020: { name: 'Admisión 2020 y 2021' },
+                C2022: { name: 'Admisión 2022 y posteriores' }
+              }}
+              value={curriculumSpec.cyear?.raw}
+              onChange={(c) => selectYear(c)}
+            />
           }
         </li>
+        }
         {planName !== '' && <li className={'inline text-md ml-3 font-semibold'}><div className={'text-sm inline mr-1 font-normal'}>Plan:</div> {planName}</li>}
       </ul>
   )

--- a/frontend/src/pages/planner/CurriculumSelector.tsx
+++ b/frontend/src/pages/planner/CurriculumSelector.tsx
@@ -187,7 +187,7 @@ const CurriculumSelector = memo(function CurriculumSelector ({
         {
         (authState?.user == null) &&
         <li className={'selectorElement'}>
-          <div className={'selectorName'}>Versión Curriculum:</div>
+          <div className={'selectorName'}>Curriculum:</div>
           {curriculumSpec != null &&
             <Selector
               name="Curriculum"

--- a/frontend/src/pages/planner/CurriculumSelector.tsx
+++ b/frontend/src/pages/planner/CurriculumSelector.tsx
@@ -34,7 +34,7 @@ const Selector = memo(function _Selector ({
   const selectedOption = value != null ? (data[value] ?? { name: `${name} Desconocido` }) : { name: 'Por Seleccionar' }
   if (value !== undefined && value !== null && data[value] === undefined) {
     useEffect(() => {
-      toast.warn(`Tu ${name} todavía no está soportado oficialmente. Los cursos pueden estar incorrectos, revisa dos veces.`, {
+      toast.warn(`Tu ${name.toLowerCase()} todavía no está soportado oficialmente. Los cursos pueden estar incorrectos, revisa dos veces.`, {
         toastId: `UNSUPPORTED_${name}`,
         autoClose: false,
         position: 'bottom-left'

--- a/frontend/src/pages/planner/ErrorTray.tsx
+++ b/frontend/src/pages/planner/ErrorTray.tsx
@@ -155,7 +155,7 @@ export const ValidationMessage: React.FC<FormatMessageProps> = ({ diag, reqCours
     }
     case 'unavail': {
       const s = diag.associated_to.length !== 1
-      return <span>{s ? 'Los' : 'El'} curso{s ? 's' : ''} {listCourses(diag.associated_to)} no se ha{s ? 'n' : ''} dictado en mucho tiempo y probablemente no se siga{s ? 'n' : ''} dictando.</span>
+      return <span>{s ? 'Los' : 'El'} curso{s ? 's' : ''} {listCourses(diag.associated_to)} no se ha{s ? 'n' : ''} dictado en mucho tiempo y posiblemente no se siga{s ? 'n' : ''} dictando.</span>
     }
     case 'unknown': {
       const s = diag.associated_to.length !== 1 ? 's' : ''

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ deps-back:
 
 deps-infra:
     @echo "{{ info_prefix }} \e[1mInstalling infrastructure dependencies...\e[0m"
-    cd backend && ansible-galaxy install -r ../infra/requirements.yml
+    cd backend && poetry run ansible-galaxy install -r ../infra/requirements.yml
 
 deps: deps-front deps-back deps-infra
 


### PR DESCRIPTION
# ¿Qué se implementa?

![image](https://github.com/open-source-uc/planner/assets/7827085/0959fa54-71f3-4a2f-91a6-4eb06582f7f2)

- No mostrar selector para usuarios logeados.
- Nombres mas comprensibles.
- No relacionado: Cambiar "el curso no se ha dictado en mucho tiempo y *probablemente* no se siga dictando" a "el curso no se ha dictado en mucho tiempo y *posiblemente* no se siga dictando", porque los ramos de titulo que aun no se implementan tiran este warning, y no se me ocurre una buena forma de determinar que ramos si se van a dictar. Ni siquiera yo se si se van a dictar algunos, como "Big Data", y incluso si supieramos no sabriamos en que año empiezan a dictarse. Seria interesante a futuro permitir a SIDING introducir un campo del estilo "empezara a dictarse en X año-semestre" y validar esto.