### PR TITLE
Mantener la eleccion de equivalencias al cambiar de programa

### DIFF
--- a/backend/app/plan/courseinfo.py
+++ b/backend/app/plan/courseinfo.py
@@ -188,7 +188,8 @@ async def add_equivalence(equiv: EquivDetails):
             f"({i}, $1, ${2+i})",
         )  # NOTE: No user-input is injected here
         query_args.append(code)
-    assert value_tuples
+    if len(value_tuples) == 0:
+        raise Exception(f"equivalence {equiv.code} has no courses?")
     await EquivalenceCourse.prisma().query_raw(
         f"""
         INSERT INTO "EquivalenceCourse" (index, equiv_code, course_code)

--- a/backend/app/plan/validation/curriculum/dump.py
+++ b/backend/app/plan/validation/curriculum/dump.py
@@ -188,8 +188,6 @@ class GraphDumper:
 
         self.out += "digraph {\n"
 
-        self.visit(self.curriculum.root)
-
         vid, flow = self.visit(self.curriculum.root)
         sink = self.mknode("")
         self.mkflowedge(vid, sink, flow, self.curriculum.root.cap)

--- a/backend/app/routes/plan.py
+++ b/backend/app/routes/plan.py
@@ -126,13 +126,14 @@ async def get_curriculum_validation_graph(
 @router.post("/generate", response_model=ValidatablePlan)
 async def generate_plan(
     passed: ValidatablePlan,
+    reference: ValidatablePlan | None = None,
     _limited: UserKey = Depends(ratelimit_guest("15/minute")),
 ):
     """
     From a base plan, generate a new plan that should lead the user to earn their title
     of choice.
     """
-    return await generate_recommended_plan(passed)
+    return await generate_recommended_plan(passed, reference)
 
 
 @router.post("/storage", response_model=PlanView)

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -97,7 +97,7 @@ class Settings(BaseSettings):
     #   write the recorded responses.
     # 4. A JSON file will be saved with previous mock data (if any) + the recorded data.
     #   Note that the file may contain sensitive data!
-    siding_record_path: Path = Path("")
+    siding_record_path: Path | Literal[""] = ""
 
     # Time to expire cached student information in seconds.
     student_info_expire: float = 1800

--- a/backend/app/sync/__init__.py
+++ b/backend/app/sync/__init__.py
@@ -143,6 +143,13 @@ async def _get_curriculum_piece(spec: CurriculumSpec) -> Curriculum:
 
 
 async def get_curriculum(spec: CurriculumSpec) -> Curriculum:
+    """
+    Get the full curriculum definition for a particular curriculum spec.
+
+    NOTE: Some users of this function, in particular `app.plan.generation`, modify the
+    returned `Curriculum`.
+    Therefore, each call to `get_curriculum` should result in a fresh curriculum.
+    """
     out = Curriculum.empty()
 
     # Fetch major (or common plan)

--- a/frontend/src/client/index.ts
+++ b/frontend/src/client/index.ts
@@ -9,6 +9,7 @@ export type { OpenAPIConfig } from './core/OpenAPI';
 export type { AccessLevelOverview } from './models/AccessLevelOverview';
 export type { AmbiguousCourseErr } from './models/AmbiguousCourseErr';
 export type { And } from './models/And';
+export type { Body_generate_plan } from './models/Body_generate_plan';
 export type { ClassId } from './models/ClassId';
 export type { ConcreteId } from './models/ConcreteId';
 export type { Const } from './models/Const';

--- a/frontend/src/client/models/Body_generate_plan.ts
+++ b/frontend/src/client/models/Body_generate_plan.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ValidatablePlan } from './ValidatablePlan';
+
+export type Body_generate_plan = {
+    passed: ValidatablePlan;
+    reference?: ValidatablePlan;
+};
+

--- a/frontend/src/client/services/DefaultService.ts
+++ b/frontend/src/client/services/DefaultService.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { AccessLevelOverview } from '../models/AccessLevelOverview';
+import type { Body_generate_plan } from '../models/Body_generate_plan';
 import type { CourseDetails } from '../models/CourseDetails';
 import type { CourseFilter } from '../models/CourseFilter';
 import type { CourseOverview } from '../models/CourseOverview';
@@ -460,7 +461,7 @@ export class DefaultService {
      * @throws ApiError
      */
     public static generatePlan(
-        requestBody: ValidatablePlan,
+        requestBody: Body_generate_plan,
     ): CancelablePromise<ValidatablePlan> {
         return __request(OpenAPI, {
             method: 'POST',


### PR DESCRIPTION
Ahorra harto tedio al momento de cambiar entre programas.
Dado que los programas tienen a veces equivalencias iguales con codigos distintos, el matcheo se hace por nombre.
Para cada equivalencia nueva se buscan las equivalencias antiguas con el mismo nombre.
Si la eleccion en alguna de estas equivalencias le calza a la equivalencia nueva, se usa.
