### PR TITLE
GitHub actions improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -9,6 +10,7 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     name: Deploy to staging
+    timeout-minutes: 15
     env:
       MACHINE: mallastest # This is the staging server
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
   check-backend:
     name: Run test and linters for the back-end
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     defaults:
       run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 permissions:
   checks: write


### PR DESCRIPTION
- `pull_request`por si solo se activa cuando una PR se abre, reabre, o se actualiza con commits.
- El timeout se añadio viendo los runs pasados. El deploy más lento fue como de 10 minutos y el lint más o menos de 1.5 minutos.
- Añadí un dispatch del deploy por si es necesario (en vez de tener que reiniciar un run antiguo).

QA

Podría añadir que solo se corra el lint cuando se modifiquen archivos de código, no se si les parece.