### PR TITLE
Priorizar validaciones de usuario

### DIFF
--- a/backend/app/plan/validation/validate.py
+++ b/backend/app/plan/validation/validate.py
@@ -21,15 +21,15 @@ async def diagnose_plan(
     curriculum = await get_curriculum(plan.curriculum)
     out = ValidationResult.empty(plan)
 
+    # Validate against user context, if there is any context
+    if user_ctx is not None:
+        validate_against_owner(plan, user_ctx, out)
+
     # Ensure course requirements are met
     course_ctx = ValidationContext(courseinfo, plan, user_ctx)
     course_ctx.validate_all(out)
 
     # Ensure the given curriculum is fulfilled
     diagnose_curriculum(courseinfo, curriculum, plan, user_ctx, out)
-
-    # Validate against user context, if there is any context
-    if user_ctx is not None:
-        validate_against_owner(plan, user_ctx, out)
 
     return out


### PR DESCRIPTION
Mostrar errores criticos de "tu curriculum no es soportado" y otros, primeros en la bandeja de errores.

Eventualmente, querremos darles "prioridad" a los errores y ordenar por eso, para desacoplar el orden en que se valida y el orden en que se muestra.
El frontend ya ordena primero los errores y despues las advertencias, esto seria granularizarlo mas solamente.