### PR TITLE
Habilidad para moderador para logearse como otro usuario

### DIFF
--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -17,11 +17,12 @@ router = APIRouter(prefix="/user")
 async def authenticate(
     next: str | None = None,
     ticket: str | None = None,
+    impersonate_rut: str | None = None,
 ):
     """
     Redirect the browser to this page to initiate authentication.
     """
-    return await login_cas(next, ticket)
+    return await login_cas(next, ticket, impersonate_rut)
 
 
 @router.get("/check")

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -2,7 +2,6 @@ import secrets
 import warnings
 from pathlib import Path
 from typing import Literal
-from urllib.parse import urlencode, urljoin
 
 from pydantic import AnyHttpUrl, BaseSettings, Field, RedisDsn, SecretStr
 
@@ -50,21 +49,6 @@ class Settings(BaseSettings):
     # This is the path used in case of prefix stripping (i.e. hosting in /api)
     # This is ignored in development mode for convenience
     root_path: str = "/api"
-
-    @property
-    def cas_callback_url(self):
-        """
-        Get the "CAS callback URL", also known as "service URL" in CAS terms.
-        After the user enters their username and password in the CAS webpage, the CAS
-        webpage will redirect the user's browser to this URL, with the CAS token
-        attached as a URL parameter.
-        Therefore, this URL must be able to receive the CAS token, create a JWT token
-        and hand it to the frontend.
-        """
-        next_url = urljoin(self.planner_url, "/")
-        auth_login_url = urljoin(self.planner_url, "/api/user/login")
-        params = urlencode({"next": next_url})
-        return f"{auth_login_url}?{params}"
 
     # Admin RUT as string. This user will always be the only admin.
     # TODO: Maybe use the username instead of the RUT, because RUTs can have zeros in

--- a/backend/app/user/auth.py
+++ b/backend/app/user/auth.py
@@ -2,6 +2,7 @@ import contextlib
 import traceback
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.parse import urlencode, urljoin
 
 from cas import CASClientV3
 from fastapi import Depends, HTTPException
@@ -14,18 +15,82 @@ from pydantic import BaseModel
 from app.settings import settings
 from app.user.key import AdminKey, ModKey, UserKey
 
-# CASClient abuses class constructors (__new__),
-# so we are using the versioned class directly
-cas_verify_client: CASClientV3 = CASClientV3(
-    service_url=settings.cas_callback_url,
-    server_url=settings.cas_server_url,
-)
+cas_client_store: CASClientV3 | None = None
 
-# Use a separate dummy CAS client instance to get the login URL.
-cas_redirect_client: CASClientV3 = CASClientV3(
-    service_url=settings.cas_callback_url,
-    server_url=settings.cas_login_redirection_url or settings.cas_server_url,
-)
+
+def _get_service_url(params: dict[str, str]) -> str:
+    """
+    Get the "CAS service URL" corresponding to this service.
+
+    Example: `https://plan.ing.uc.cl/api/user/login`
+    Another example: `https://plan.ing.uc.cl/api/user/login?next=https://plan.ing.uc.cl`
+
+    After the user logs in at the CAS login page, they will be redirected to this URL.
+    This URL must be whitelisted in the official CAS server.
+
+    `params` are query parameters to include in the URL.
+    """
+
+    # We must import this module inside a function
+    # Otherwise we would form an import cycle
+    from app.routes.user import router as user_router
+
+    callback_endpoint = "/api" + user_router.url_path_for("authenticate")
+    url = urljoin(settings.planner_url, callback_endpoint)
+    if params:
+        query_params = urlencode(params)
+        url = f"{url}?{query_params}"
+    return url
+
+
+def _get_cas_client() -> CASClientV3:
+    """
+    Lazily get the CAS client.
+
+    This must be lazy, because in order to get the service URL we must call
+    `_get_service_url`, which imports `app.routes.user`.
+    If we imported `app.routes.user` outside of a function, it would cause an import
+    loop.
+    """
+    global cas_client_store
+    if cas_client_store is None:
+        cas_client_store = CASClientV3(
+            service_url=_get_service_url({}),
+            server_url=settings.cas_server_url,
+        )
+    return cas_client_store
+
+
+def _get_login_url(service_params: dict[str, str]) -> str:
+    """
+    Get the login URL.
+    Redirect the user to this URL to start a CAS login.
+
+    Example: `https://sso.uc.cl/cas/login?service=https://plan.ing.uc.cl/api/user/login?next=https://plan.ing.uc.cl`
+    This means:
+    1. Go to `sso.uc.cl/cas/login` and let the user enter their username and password.
+    2. When done, redirect to `plan.ing.uc.cl/api/user/login` with the CAS token, to
+        generate a JWT token.
+    3. When the token is generated, redirect to `plan.ing.uc.cl` with the JWT token.
+
+    `service_params` are extra URL parameters to include in step 2.
+    """
+
+    # Include the `next` parameter to indicate where to redirect after generating the
+    # JWT token.
+    service_params["next"] = urljoin(settings.planner_url, "/")
+    # Generate the service URL, including the `next` parameter and any extra parameters
+    service_url = _get_service_url(service_params)
+
+    # The base URL for logging in
+    # Something like `https://sso.uc.cl/cas`
+    cas_login_server = settings.cas_login_redirection_url or settings.cas_server_url
+    # The login URL
+    # Something like `https://sso.uc.cl/cas/login`
+    cas_login_url = urljoin(cas_login_server, "login")
+    # The URL parameters to include in the login request
+    cas_login_params = urlencode({"service": service_url})
+    return f"{cas_login_url}?{cas_login_params}"
 
 
 async def _is_admin(rut: str):
@@ -155,12 +220,10 @@ async def login_cas(
     if ticket is None:
         # User wants to authenticate
         # Redirect to authentication page
-        cas_login_url: Any = cas_redirect_client.get_login_url()  # pyright: ignore
-        if not isinstance(cas_login_url, str):
-            return HTTPException(
-                status_code=500,
-                detail="CAS redirection URL not found",
-            )
+        params = {}
+        if impersonate_rut is not None:
+            params["impersonate_rut"] = impersonate_rut
+        cas_login_url = _get_login_url(params)
         return RedirectResponse(cas_login_url)
 
     # User has just authenticated themselves with CAS, and were redirected here
@@ -177,7 +240,7 @@ async def login_cas(
             username,
             attributes,
             _pgtiou,
-        ) = cas_verify_client.verify_ticket(  # pyright: ignore
+        ) = _get_cas_client().verify_ticket(  # pyright: ignore
             ticket,
         )
     except Exception:  # noqa: BLE001 (CAS lib is untyped)

--- a/backend/app/user/key.py
+++ b/backend/app/user/key.py
@@ -11,11 +11,10 @@ class UserKey:
     function requires authorization to access the user".
 
     Example:
-    << user = UserKey(username="usuario", rut="12345678-9")
-    >> UserKey(username='usuario', rut='12345678-9')
+    << user = UserKey(rut="12345678-9")
+    >> UserKey(rut='12345678-9')
     """
 
-    username: str
     rut: str
 
 
@@ -29,15 +28,15 @@ class ModKey(UserKey):
     function requires mod authorization".
 
     Example:
-    << mod = ModKey(username="moderador", rut="12345678-9")
-    >> ModKey(username='moderador', rut='12345678-9')
+    << mod = ModKey(rut="12345678-9")
+    >> ModKey(rut='12345678-9')
     """
 
     def as_any_user(self, user_rut: str) -> UserKey:
         """
         Moderators can access the resources of any user.
         """
-        return UserKey("", user_rut)
+        return UserKey(user_rut)
 
 
 class AdminKey(ModKey):
@@ -50,6 +49,6 @@ class AdminKey(ModKey):
     function requires admin authorization".
 
     Example:
-    << admin = AdminKey(username="administrador", rut="12345678-9")
-    >> AdminKey(username='administrador', rut='12345678-9')
+    << admin = AdminKey(rut="12345678-9")
+    >> AdminKey(rut='12345678-9')
     """

--- a/backend/prisma/migrations/20230721211317_normalize_ruts/migration.sql
+++ b/backend/prisma/migrations/20230721211317_normalize_ruts/migration.sql
@@ -1,0 +1,7 @@
+-- Remove leading zeros from RUTs.
+
+UPDATE "AccessLevel"
+SET user_rut = TRIM(LEADING '0' FROM user_rut);
+
+UPDATE "Plan"
+SET user_rut = TRIM(LEADING '0' FROM user_rut);

--- a/frontend/src/client/services/DefaultService.ts
+++ b/frontend/src/client/services/DefaultService.ts
@@ -795,12 +795,14 @@ export class DefaultService {
      * Redirect the browser to this page to initiate authentication.
      * @param next
      * @param ticket
+     * @param impersonateRut
      * @returns any Successful Response
      * @throws ApiError
      */
     public static authenticate(
         next?: string,
         ticket?: string,
+        impersonateRut?: string,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
             method: 'GET',
@@ -808,6 +810,7 @@ export class DefaultService {
             query: {
                 'next': next,
                 'ticket': ticket,
+                'impersonate_rut': impersonateRut,
             },
             errors: {
                 422: `Validation Error`,


### PR DESCRIPTION
# ¿Qué se implementa?

- Permitir a los moderadores logearse como cualquier usuario usando `/api/user/login?impersonate_rut=...`.
- Eliminar el campo `username` de `UserKey`, `ModKey` y `AdminKey`. No estaba siendo usado, y en muchos casos ni siquiera estaba disponible. Eran bugs esperando a aparecer.
- Refactorear la formulación de URLs para login. Permite pasar parámetros a través de CAS, lo que era necesario para mantener el parámetro `impersonate_rut` a través de la pantalla de login. Ya no es necesario mantener dos instancias de `CASClient`.
- Normalizar los RUTs. A veces los RUTs vienen con ceros al frente, y esto puede causar confusion con `impersonate_rut`: si se usa un rut como `12345678-K`, este es un usuario distinto a `012345678-K` (el RUT que entrega CAS). Agregue una migracion para eliminar estos ceros, y agregue normalizacion al momento de crear tokens, procesar el `impersonate_rut` y decodificar tokens (para los tokens que aun existen y que tienen `0` en el rut).

# Importante

Hay que probar harto esto igual. Lo probe bastante: la migracion elimina los ceros y los tokens antiguos siguen funcionando. Igual no hace mal un poco mas de testing.